### PR TITLE
Fix for legacy schemas with uppercase table names

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -25,7 +25,7 @@ module Globalize
       end
 
       def class_name
-        class_name = table_name[table_name_prefix.length..-(table_name_suffix.length + 1)].camelize
+        class_name = table_name[table_name_prefix.length..-(table_name_suffix.length + 1)].downcase.camelize
         pluralize_table_names ? class_name.singularize : class_name
       end
 

--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -55,3 +55,8 @@ end
 class MigratedWithUltraLongModelName < ActiveRecord::Base
   translates :name
 end
+
+class UppercaseTableName < ActiveRecord::Base
+  set_table_name "UPPERCASE_TABLE_NAME"
+  translates :name
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -88,4 +88,14 @@ ActiveRecord::Schema.define do
     t.index :tag
     t.index :created_at
   end
+
+  create_table 'UPPERCASE_TABLE_NAME', :force => true do |t|
+    t.string :name
+  end
+
+  create_table :uppercase_table_name_translations, :force => true do |t|
+    t.integer 'UPPERCASE_TABLE_NAME_id'
+    t.string     :locale
+    t.string     :name
+  end
 end

--- a/test/globalize3/translation_class_test.rb
+++ b/test/globalize3/translation_class_test.rb
@@ -36,6 +36,12 @@ class TranslationClassTest < Test::Unit::TestCase
       end
     end
   end
+
+  test "can create a translation class for a model with an uppercase table name" do
+    assert_nothing_raised do
+      UppercaseTableName.create
+    end
+  end
   
   test "does not override existing translation class" do
     assert PostTranslation.new.respond_to?(:existing_method)


### PR DESCRIPTION
I'm working on an app that interfaces with some old php code's tables (which need to stay the way they are b/c the php is still in use somewhat), and the names are all uppercase and not pluralized the way Rails expects them to be.  Rails handles this just fine with set_table_name and setting foreign keys explicitly.  I needed to patch globalize to make it work.  Here's why:

```
irb(main):003:0> "UPPERCASE_TABLE_NAME".camelize
=> "UPPERCASETABLENAME"
irb(main):004:0> "UPPERCASE_TABLE_NAME".camelize.foreign_key
=> "uppercasetablename_id"
irb(main):005:0> "UPPERCASE_TABLE_NAME".downcase.camelize
=> "UppercaseTableName"
irb(main):006:0> "UPPERCASE_TABLE_NAME".downcase.camelize.foreign_key
=> "uppercase_table_name_id"
```

Sorry if my test case isn't the best way to test this.  It wrote it, it failed the way I expected it to, then I added my fix and everything passed.
