### PR TITLE
make tests  rails-3.0.3 compatible

### DIFF
--- a/test/i18n/missing_translations_test.rb
+++ b/test/i18n/missing_translations_test.rb
@@ -25,11 +25,11 @@ class LogMissingTranslationsTest < Test::Unit::TestCase
 
   test "still returns the exception message for MissingTranslationData exceptions" do
     result = I18n.send(:missing_translations_log_handler, @exception, @locale, @key, @options)
-    assert_equal 'translation missing: en, foo', result
+    assert_match /translation missing: en(\W+)foo/, result
   end
   
   test "logs the missing translation to I18n.missing_translations_logger" do
     I18n.send(:missing_translations_log_handler, @exception, @locale, @key, @options)
-    assert_equal 'translation missing: en, foo', @logger
+    assert_match /translation missing: en(\W+)foo/, @logger
   end
 end


### PR DESCRIPTION
Rails 3.0.3 (don't know which part exactly) introduced a change of translation missing string: it's not longer "translation missing: en, foo" but "translation missing: en.foo".
I've changed the assertions in test suite to fit both versions.
