### PR TITLE
Fix xml_serializer patch

### DIFF
--- a/lib/patches/active_record/xml_attribute_serializer.rb
+++ b/lib/patches/active_record/xml_attribute_serializer.rb
@@ -2,7 +2,9 @@ require 'active_record/serializers/xml_serializer'
 
 ActiveRecord::XmlSerializer::Attribute.class_eval do
   def compute_type_with_translations
-    if @serializable.class.translated_attribute_names.include?(name.to_sym)
+    klass = @serializable.class
+    if klass.respond_to?(:translated_attribute_names) &&
+       klass.translated_attribute_names.include?(name.to_sym)
       :string
     else
       compute_type_without_translations

--- a/test/globalize3_test.rb
+++ b/test/globalize3_test.rb
@@ -101,6 +101,12 @@ class Globalize3Test < Test::Unit::TestCase
     assert post.to_xml =~ %r(<content>bar</content>)
   end
 
+  test "to_xml doesn't affect untranslated models" do
+    blog = Blog.create(:description => "my blog")
+    blog.reload
+    assert blog.to_xml =~ %r(<description>my blog</description>)
+  end
+
   test "translated_locales returns locales that have translations" do
     first = Post.create!(:title => 'title', :locale => :en)
     first.update_attributes(:title => 'Title', :locale => :de)


### PR DESCRIPTION
On untranslated models, `to_xml` was broken because we call `@serializable.class.translated_attribute_names` without checking that the model's class has the `translated_attribute_names` method.
