### PR TITLE
Make sure write_attribute returns the written value

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -24,8 +24,11 @@ module Globalize
       end
 
       def write_attribute(name, value, locale = nil)
-        super(name, value)
-        globalize.write(locale || Globalize.locale, name, value) if translated?(name)
+        # Make sure that we return some value as some methods might 
+        # rely on the data
+        return_value = super(name, value)
+        return_value = globalize.write(locale || Globalize.locale, name, value) if translated?(name)
+        return_value
       end
 
       def read_attribute(name, locale = nil)

--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -18,6 +18,12 @@ class AttributesTest < Test::Unit::TestCase
     attributes = post.attributes.slice('id', 'blog_id', 'title', 'content')
     assert_equal({ 'id' => post.id, 'blog_id' => nil, 'title' => 'foo', 'content' => nil }, attributes)
   end
+  
+  test "write_attribute for non-translated attributes should return the value" do
+    user = User.create(:name => 'Max Mustermann', :email => 'max@mustermann.de')
+    new_email = 'm.muster@mann.de'
+    assert_equal new_email, user.write_attribute('email', new_email)
+  end
 
   test 'translated_attribute_names returns translated attribute names' do
     assert_equal [:title, :content], Post.translated_attribute_names & [:title, :content]
@@ -116,4 +122,6 @@ class AttributesTest < Test::Unit::TestCase
     end
     assert_equal 'Titel', post.title(:de)
   end
+  
+  
 end


### PR DESCRIPTION
I found a little bug in globalize3. The write_attribute method is supposed to return the written value. I am not sure where else it is used, but at least the ActiveRecord touch method relies on the returned data. Otherwise it sets the models updated_at column to NULL.
