### PR TITLE
resolving some strange problem with Rails 3.0.3

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -74,7 +74,7 @@ module Globalize
           value, requested_locale = nil, locale
 
           Globalize.fallbacks(locale).each do |fallback|
-            translation = translations.detect { |t| t.locale == fallback }
+            translation = translations.to_a.detect { |t| t.locale == fallback }
             value  = translation && translation.send(name)
             locale = fallback && break if value
           end
@@ -97,3 +97,4 @@ module Globalize
     end
   end
 end
+


### PR DESCRIPTION
With Rails 3.0.3, I got a strange problem when asking for a translated columns. Here is the stack trace :

ActionView::Template::Error (undefined method `name' for #<Enumerable::Enumerator:0x7f45cdd5df30>):
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/adapter.rb:78:in`send'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/adapter.rb:78:in `fetch_attribute'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/adapter.rb:76:in`each'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/adapter.rb:76:in `fetch_attribute'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/adapter.rb:19:in`fetch'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/instance_methods.rb:36:in `read_attribute'
  /home/yann/.bundler/ruby/1.8/globalize3-2a09f5279c9a/lib/globalize/active_record/class_methods.rb:82:in`name'

Indeed, active_record/adapter.rb line 77, I got a ActiveRecord::Relation object which acts as a Enumerable::Enumerator. Don't know if it's the right thing to do here, but at least it resolved my problem.
