### PR TITLE
Removes #find_first_by and adds #find_all_by

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -60,7 +60,7 @@ module Globalize
       end
 
       def respond_to?(method, *args, &block)
-        method.to_s =~ /^find_by_(\w+)$/ && translated?($1.to_sym) || super
+        method.to_s =~ /^find_(all_|)by_(\w+)$/ && translated?($2.to_sym) || super
       end
 
       def method_missing(method, *args)

--- a/test/globalize3/dynamic_finders_test.rb
+++ b/test/globalize3/dynamic_finders_test.rb
@@ -25,4 +25,11 @@ class DynamicFindersTest < Test::Unit::TestCase
       post.save
     end
   end
+
+  test "respond_to? should return true for all possible dynamic finders" do
+    assert Post.respond_to?(:find_by_title)
+    assert Post.respond_to?(:find_all_by_title)
+    assert !Post.respond_to?(:find_by_foo)
+    assert !Post.respond_to?(:find_all_by_foo)
+  end
 end


### PR DESCRIPTION
As described in [this issue](https://github.com/svenfuchs/globalize3/issues#issue/11), `#find_by` currently returns an Array instead of a single object. There is a `find_first_by` method to get the single object.
ActiveRecord conventions goes the other way around, there you have a `find_by` method that returns a single object and a `find_all_by` method that returns an Array of objects.
