### PR TITLE
Also use fallbacks when value is blank (and not just nil)

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -76,7 +76,7 @@ module Globalize
           Globalize.fallbacks(locale).each do |fallback|
             translation = translations.to_a.detect { |t| t.locale == fallback }
             value  = translation && translation.send(name)
-            locale = fallback && break if value
+            locale = fallback && break unless value.blank?
           end
 
           set_metadata(value, :locale => locale, :requested_locale => requested_locale)


### PR DESCRIPTION
I have written a plugin in which it is possible to define multiple translations at once (bulk create/update).

In there it is possible that some fields get left out in order to fall back to the default locale. Because of the way it get's saved into the database (by using Rails in this case), the fallbacks get a blank string instead of nil.

These values would no longer fall back to the default locale, because of the code checking it to be nil (instead of blank).

I have (not yet) written a test for this. That aside, I wasn't able to get the fallbacks test running. Could you give me some insight on how you did it?
