### PR TITLE
Don't write to untranslated_attributes when changing a translated one

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -26,10 +26,6 @@ module Globalize
       def write_attribute(name, value, options = {})
         # raise 'y' if value.nil? # TODO.
 
-        # Make sure that we return some value as some methods might
-        # rely on the data
-        return_value = super(name, value)
-
         if translated?(name)
           # Deprecate old use of locale
           unless options.is_a?(Hash)
@@ -37,9 +33,11 @@ module Globalize
             options = {:locale => options}
           end
           options = {:locale => nil}.merge(options)
-          return_value = globalize.write(options[:locale] || Globalize.locale, name, value)
+          attribute_will_change! name.to_s
+          globalize.write(options[:locale] || Globalize.locale, name, value)
+        else
+          super(name, value)
         end
-        return_value
       end
 
       def read_attribute(name, options = {})

--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -122,5 +122,12 @@ class AttributesTest < Test::Unit::TestCase
     end
     assert_equal 'Titel', post.title(:de)
   end
-  
+
+  test 'modifying a translated attribute does not change the untranslated value' do
+    post = Post.create(:title => 'title')
+    before = post.untranslated_attributes['title']
+    post.title = 'changed title'
+    assert_equal post.untranslated_attributes['title'], before
+  end
+
 end


### PR DESCRIPTION
Writing to a translated attribute causes the untranslated attribute
with the same name to be modified, due to a rogue call to super in
write_attribute.

The parent method should only be called if the attribute is not
translated. If it is translated, to keep dirty objects tracking
working we just call attribute_will_change! before writing the
new value.

Many thanks to @pilif for the help in tracking this one down.
