### PR TITLE
Fixed tests in 1.8.7 - new hash syntax doesn't work on it and fixed stack level too deep.

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -72,7 +72,7 @@ module Globalize
       end
 
       def supported_on_missing?(method_id)
-        return super unless respond_to?(:translated_attribute_names)
+        #return super unless respond_to?(:translated_attribute_names)
         match = ::ActiveRecord::DynamicFinderMatch.match(method_id) || ::ActiveRecord::DynamicScopeMatch.match(method_id)
         return false if match.nil?
 

--- a/test/globalize3/dynamic_finders_test.rb
+++ b/test/globalize3/dynamic_finders_test.rb
@@ -37,7 +37,7 @@ class DynamicFindersTest < Test::Unit::TestCase
     post.update_attributes!(:title => he, :locale => :he)
 
     with_fallbacks do
-      I18n.fallbacks = {de: [:de, :en], he: [:he, :en], en: [:en]}
+      I18n.fallbacks = {:de => [:de, :en], :he => [:he, :en], :en => [:en]}
 
       with_locale(:en) do
         assert Post.find_by_title(en)


### PR DESCRIPTION
fixes tests for 1.8.7 & 1.9.2 because respond_to? was calling supported_on_missing? which was calling respond_to? and so on and so on
