### PR TITLE
Use destroy when deleting associated objects.

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -16,7 +16,7 @@ module Globalize
 
         has_many :translations, :class_name  => translation_class.name,
                                 :foreign_key => class_name.foreign_key,
-                                :dependent   => :delete_all,
+                                :dependent   => :destroy,
                                 :extend      => HasManyExtensions
 
         after_create :save_translations!


### PR DESCRIPTION
Reason behind this is that in case there are other associations defined in translation model (just like in case of seo_meta plugin https://github.com/parndt/seo_meta/blob/master/lib/seo_meta.rb#L24-27) then those associated objects won't get deleted when deleting translation.
