### PR TITLE
Added :copy option to translates macro

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -7,6 +7,14 @@ module Globalize
   autoload :Versioning,   'globalize/versioning'
 
   class << self
+    def default_locale
+      I18n.default_locale
+    end
+    
+    def default_locale?(lc)
+      (lc || locale) == default_locale
+    end
+    
     def locale
       read_locale || I18n.locale
     end

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -20,6 +20,7 @@ module Globalize
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions
 
+        before_save  :copy_default_translations! if options[:copy]
         after_create :save_translations!
         after_update :save_translations!
 


### PR DESCRIPTION
This makes sure the translated values from the default locale's Translation are copied to the master model. It triggers changed_attributes (~ dirty) to make it work. The particular use case was working with accepts_nested_attributes_for :translations, where the master object is bypassed entirely, not being aware of changes.
