### PR TITLE
Adjustment for Rails 3.1

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -11,15 +11,7 @@ module Globalize
         super.merge(translated_attributes)
       end
 
-      def attributes=(attributes, *args)
-        with_given_locale(attributes) { super }
-      end
-
-      def update_attributes!(attributes, *args)
-        with_given_locale(attributes) { super }
-      end
-
-      def update_attributes(attributes, *args)
+      def assign_attributes(attributes, options = {})
         with_given_locale(attributes) { super }
       end
 


### PR DESCRIPTION
Rails 3.1 is using a new method "assign_attributes" to update the attributes. So to allow ":locale => :en" in the parameters, this adjustment is needed.
