### PR TITLE
Fix exceptions when i18n metadata is used

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -79,7 +79,7 @@ module Globalize
       end
 
       def set_metadata(object, metadata)
-        object.translation_metadata.merge!(meta_data) if object.respond_to?(:translation_metadata)
+        object.translation_metadata.merge!(metadata) if object.respond_to?(:translation_metadata)
         object
       end
 


### PR DESCRIPTION
When you include I18n::Backend::Metadata, Globalize throws exceptions due to a typo.
