### PR TITLE
added test for dynamic finder match translation and fix using reload (issue #100)

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -98,7 +98,11 @@ module Globalize
           scope = scope.send(:"scoped_by_#{unt}", arguments[index])
         end
 
-        return scope.send(match.finder) if match.is_a?(::ActiveRecord::DynamicFinderMatch)
+        if match.is_a?(::ActiveRecord::DynamicFinderMatch)
+          found = scope.send(match.finder)
+          return nil if found.nil?
+          return found.is_a?(Array) ? found.map(&:reload) : found.reload
+        end
         return scope
       end
 

--- a/test/globalize3/dynamic_finders_test.rb
+++ b/test/globalize3/dynamic_finders_test.rb
@@ -77,6 +77,13 @@ class DynamicFindersTest < Test::Unit::TestCase
     end
   end
 
+  test "records returned by dynamic finders have all translations" do
+    post = Post.create(:title => 'a title')
+    Globalize.with_locale(:ja) { post.update_attributes(:title => 'タイトル') }
+    post_by_df = Post.find_by_title('a title')
+    assert_equal post.translations, post_by_df.translations
+  end
+
   test "responds to possible dynamic finders" do
     assert Post.respond_to?(:find_by_title)
     assert Post.respond_to?(:find_all_by_title)


### PR DESCRIPTION
This commit addresses issue #100 regarding translations being left behind after destroying an object that was found using dynamic finders on translated attributes. It doesn't handle the case when a scope is returned.

If there's a better way to do this, I can update the fix, just let me know. This seemed like the simplest solution.
