### PR TITLE
Correctly handle nil assignments

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -21,7 +21,7 @@ module Globalize
 
       def fetch(locale, name)
         Globalize.fallbacks(locale).each do |fallback|
-          value = fetch_stash(fallback, name) || fetch_attribute(fallback, name)
+          value = stash.contains?(fallback, name) ? fetch_stash(fallback, name) : fetch_attribute(fallback, name)
 
           unless fallbacks_for?(value)
             set_metadata(value, :locale => fallback, :requested_locale => locale)

--- a/test/globalize3/dirty_tracking_test.rb
+++ b/test/globalize3/dirty_tracking_test.rb
@@ -58,4 +58,23 @@ class DirtyTrackingTest < Test::Unit::TestCase
 
     assert_equal ['content'], child.changed
   end
+
+  test 'dirty tracking works for blank assignment' do
+    post = Post.create(:title => 'title', :content => 'content')
+    assert_equal [], post.changed
+
+    post.title = ''
+    assert_equal({ 'title' => ['title', ''] }, post.changes)
+    post.save
+  end
+
+  test 'dirty tracking works for nil assignment' do
+    post = Post.create(:title => 'title', :content => 'content')
+    assert_equal [], post.changed
+
+    post.title = nil
+    assert_equal({ 'title' => ['title', nil] }, post.changes)
+    post.save
+  end
+
 end


### PR DESCRIPTION
Small change that addresses #51

When assigning nil to a translated attribute, active_record changes are correctly tracked and therefore validations (if any) have a chance to fire correctly.

Tests added to cover the dirty changes tracking.

This may have implications for fallback configuration, however this change didn't break any existing tests so I'm assuming all is well ;-)
