### PR TITLE
Added integer type

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -127,7 +127,7 @@ module Globalize
         end
 
         def valid_field_type?(name, type)
-          !translated_attribute_names.include?(name) || [:string, :text].include?(type)
+          !translated_attribute_names.include?(name) || [:string, :text, :integer].include?(type)
         end
 
         def translation_index_name


### PR DESCRIPTION
Sometimes when we have nested tree we want to have sorted tree in different order (in each language by name), for that we must add integer field for left, right attributes to translation table.
