### PR TITLE
get fallbacks from record

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -20,7 +20,7 @@ module Globalize
       end
 
       def fetch(locale, name)
-        Globalize.fallbacks(locale).each do |fallback|
+        record.globalize_fallbacks(locale).each do |fallback|
           value = stash.contains?(fallback, name) ? fetch_stash(fallback, name) : fetch_attribute(fallback, name)
 
           unless fallbacks_for?(value)

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -137,6 +137,10 @@ module Globalize
         @translation_caches[locale]
       end
 
+      def globalize_fallbacks(locale)
+        Globalize.fallbacks(locale)
+      end
+
       def rollback
         @translation_caches[::Globalize.locale] = translation.previous_version
       end

--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -65,6 +65,10 @@ end
 
 class Task < ActiveRecord::Base
   translates :name, :fallbacks_for_empty_translations => true
+  cattr_accessor :fallbacks
+  def globalize_fallbacks(locale)
+    self.class.fallbacks || super
+  end
 end
 
 class NewsItem < ActiveRecord::Base

--- a/test/globalize3/fallbacks_test.rb
+++ b/test/globalize3/fallbacks_test.rb
@@ -152,6 +152,25 @@ class TranslatedTest < Test::Unit::TestCase
 
     assert_equal [:de], task.translations.map(&:locale).sort
   end
+
+  test 'fallback overwritten in model' do
+    I18n.fallbacks.clear
+    Task.fallbacks = [:en, :de]
+    I18n.locale = :de
+
+    task = Task.create(:name => 'foo')
+    assert_equal 'foo', task.name
+
+    I18n.locale = :en
+    assert_equal 'foo', task.name
+    task.name = 'bar'
+    assert_equal 'bar', task.name
+
+    I18n.locale = :fr
+    assert_equal 'bar', task.name
+
+    Task.fallbacks = nil
+  end
 end
 # TODO should validate_presence_of take fallbacks into account? maybe we need
 #   an extra validation call, or more options for validate_presence_of.


### PR DESCRIPTION
Small change to get the fallbacks from the model instead of the Globalize module, so the model can control the fallbacks
