### PR TITLE
Make it possible to call 'translates' several times to support meta programming.

### DIFF
--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -71,3 +71,8 @@ class NewsItem < ActiveRecord::Base
   translates :name, :foreign_key => :news_id
   self.table_name = :news
 end
+
+class Page < ActiveRecord::Base
+  translates :title
+  translates :body
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -115,4 +115,14 @@ ActiveRecord::Schema.define do
     t.string     :locale
     t.string     :title
   end
+
+  create_table :pages, :force => true do |t|
+  end
+
+  create_table :page_translations, :force => true do |t|
+    t.integer    :page_id
+    t.string     :locale
+    t.string     :title
+    t.string     :body
+  end
 end

--- a/test/globalize3_test.rb
+++ b/test/globalize3_test.rb
@@ -162,4 +162,10 @@ class Globalize3Test < Test::Unit::TestCase
     assert_translated translated_comment, :en, :content, 'content'
     assert_translated translated_comment, :de, :content, 'Inhalt'
   end
+
+  test "calling translates a second times adds the new attributes to the translated attributes" do
+    page = Page.new :title => 'Wilkommen', :body => 'Ein body', :locale => :de
+    assert_translated page, :de, :title, 'Wilkommen'
+    assert_translated page, :de, :body, 'Ein body'
+  end
 end


### PR DESCRIPTION
Hi!

I use globalize3 with refinery and realized that it wasn't possible to add more translated attributes after the first 'translates' was called.

So I made translates do all the initializing only if it isn't already called, in other cases it just adds the attributes that isn't translated already.

...and the diff looks worse then it is, if you look at the raw file you see that I haven't changed that much.
