### PR TITLE
add support for scope option on uniqueness validation for translated attributes

### DIFF
--- a/lib/patches/active_record/uniqueness_validator.rb
+++ b/lib/patches/active_record/uniqueness_validator.rb
@@ -5,18 +5,31 @@ ActiveRecord::Validations::UniquenessValidator.class_eval do
     klass = record.class
     if klass.translates? && klass.translated?(attribute)
       if respond_to? :build_relation
-       finder_class = klass.translation_class
+        finder_class = klass.translation_class
         table = finder_class.arel_table
 
         relation = build_relation(finder_class, table, attribute, value).and(table[:locale].eq(Globalize.locale))
         relation = relation.and(table[klass.reflect_on_association(:translations).foreign_key].not_eq(record.send(:id))) if record.persisted?
 
-  #      TODO: add scope with translated attributes
-        if options[:scope]
-          ActiveRecord::Base.logger.warn("WARNING: Globalize3 does not currently support `scope` option on uniqueness validation for translated attributes.")
+        translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
+        untranslated_scopes = Array(options[:scope]) - translated_scopes
+
+        untranslated_scopes.each do |scope_item|
+          scope_value = record.send(scope_item)
+          reflection = klass.reflect_on_association(scope_item)
+          if reflection
+            scope_value = record.send(reflection.foreign_key)
+            scope_item = reflection.foreign_key
+          end
+          relation = relation.and(find_finder_class_for(record).arel_table[scope_item].eq(scope_value))
         end
 
-        if finder_class.unscoped.where(relation).exists?
+        translated_scopes.each do |scope_item|
+          scope_value = record.send(scope_item)
+          relation = relation.and(table[scope_item].eq(scope_value))
+        end
+
+        if klass.unscoped.with_translations.where(relation).exists?
           record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
         end
       else

--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -31,6 +31,9 @@ module Nested
   end
 end
 
+class ScopedValidatee < ActiveRecord::Base
+  translates :string, :scope_string
+end
 
 class Parent < ActiveRecord::Base
   translates :content

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -71,6 +71,17 @@ ActiveRecord::Schema.define do
     t.string     :string
   end
 
+  create_table :scoped_validatees, :force => true do |t|
+    t.integer :integer, :another_integer
+  end
+
+  create_table :scoped_validatee_translations, :force => true do |t|
+    t.references :scoped_validatee
+    t.string     :locale
+    t.string     :string
+    t.string     :scope_string
+  end
+
   create_table :users, :force => true do |t|
     t.string   :email
     t.datetime :created_at

--- a/test/globalize3/validations_test.rb
+++ b/test/globalize3/validations_test.rb
@@ -75,10 +75,10 @@ class ValidationsTest < Test::Unit::TestCase
     assert Validatee.new(:string => '1').valid?
   end
 
-  test "validates_uniqueness_of" do
+  test "validates_uniqueness_of (basic tests)" do
     Validatee.class_eval { validates_uniqueness_of :string }
     # make sure Validatee and Validatee::Translation table ids are not the same (for tests)
-    10.times { Validatee::Translation.create }
+    10.times { Validatee::Translation.create :locale => "en" }
     validatee = Validatee.create!(:string => 'a')
 
     #create
@@ -95,12 +95,36 @@ class ValidationsTest < Test::Unit::TestCase
     assert !validatee.update_attributes(:string => 'b')
     Globalize.with_locale(:de) { assert validatee.update_attributes(:string => 'b') }
 
+  end
+
+  test "validates_uniqueness_of (with nested model)" do
     # nested model (to check for this: https://github.com/resolve/refinerycms/pull/1486 )
     Nested::NestedValidatee.class_eval { validates_uniqueness_of :string }
     nested_validatee = Nested::NestedValidatee.create!(:string => 'a')
     Nested::NestedValidatee.create!(:string => 'b')
     assert nested_validatee.update_attributes(:string => 'a')
     assert !nested_validatee.update_attributes(:string => 'b')
+  end
+
+  test "validates_uniqueness_of (with options[:scope])" do
+    # uniqueness validation on translated attribute with scope
+    ScopedValidatee.class_eval { validates_uniqueness_of :string, :scope => [:integer,:scope_string] }
+    ScopedValidatee.create!(:string => 'c', :integer => 1, :scope_string => 'd')
+
+    assert !ScopedValidatee.new(:string => 'c', :integer => 1, :scope_string => 'd').valid?
+
+    assert ScopedValidatee.new(:string => 'c', :integer => 1, :scope_string => 'a').valid?
+    assert ScopedValidatee.new(:string => 'c', :integer => 1).valid?
+    assert ScopedValidatee.new(:string => 'c', :integer => 0, :scope_string => 'd').valid?
+    assert ScopedValidatee.new(:string => 'c', :scope_string => 'd').valid?
+    assert ScopedValidatee.new(:string => 'c', :integer => 0, :scope_string => 'a').valid?
+
+    # check to make sure standard uniqueness validation still works
+    ScopedValidatee.class_eval { validates_uniqueness_of :another_integer }
+    ScopedValidatee.create!(:string => 'abc', :another_integer => 1)
+
+    assert !ScopedValidatee.new(:another_integer => 1).valid?
+    assert ScopedValidatee.new(:another_integer => 0).valid?
   end
 
   # test "validates_associated" do


### PR DESCRIPTION
The code is mostly taken from rails core uniqueness validation, with a couple lines that pass translated/untranslated attributes to the right table when creating relations. If I'm missing anything let me know and I'll add code/tests.
