### PR TITLE
Propertly set belongs_to association

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -45,7 +45,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to name.underscore.gsub('/', '_')
+          klass.belongs_to name.underscore.gsub('/', '_').to_sym
           klass
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ class Test::Unit::TestCase
   end
 
   def assert_association(model, type, other)
-    assert model.reflect_on_all_associations(type).any? { |a| a.name.to_s == other.to_s }
+    assert model.reflect_on_all_associations(type).any? { |a| a.name == other }
   end
 
   def assert_translated(record, locale, attributes, translations)


### PR DESCRIPTION
Association key must be a symbol, not a string
