### PR TITLE
Add failing test to show error in saving translations

### DIFF
--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -54,6 +54,18 @@ class AttributesTest < Test::Unit::TestCase
     assert_translated post, :de, :title, 'Titel'
   end
 
+  test "a translated attribute reader does not create empty translations when loaded in a new locale" do
+    post = Post.create(:title => 'title')
+    assert_equal 1, post.translations.length
+    I18n.locale = :de
+    
+    post.reload
+    assert_equal 1, post.translations.length
+    
+    post.save
+    assert_equal 1, post.translations.length
+  end
+
   test "a translated attribute reader returns the correct translation for an unsaved record after locale switching" do
     post = Post.create(:title => 'title')
     with_locale(:de) { post.title = 'Titel' }


### PR DESCRIPTION
I am running into an issue where if I create a new model with translated attributes in one locale and then reload it in a different locale (for instance, a user visits the page, and performs some action with forces a model save) and save it without any changes to the translated attributes, a new translation record is created with nil values for the locale. Is this expected behaviour?

I can see in lib/globalize/active_record/adapter.rb that the logic in save_translation! is working, and the translations aren't being saved there. But somewhere else it is happening. I suspect this is actually an active record thing.
