### PR TITLE
Secondary unsaved translations are erroneously deleted by `write_attribute`

### DIFF
--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -6,6 +6,7 @@ class Post < ActiveRecord::Base
   translates :title, :content, :published, :published_at, :versioning => true
   validates_presence_of :title
   scope :with_some_title, :conditions => { :title => 'some_title' }
+  accepts_nested_attributes_for :translations
 end
 
 class PostTranslation < ActiveRecord::Base

--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -142,4 +142,18 @@ class AttributesTest < Test::Unit::TestCase
     assert_equal post.untranslated_attributes['title'], before
   end
 
+  test 'modifying a translated attribute does not remove secondary unsaved translations' do
+    post = with_locale(:en) do
+      post = Post.new(:translations_attributes => {
+        "0" => { :locale => 'en', :title => 'title' },
+        "1" => { :locale => 'it', :title => 'titolo' }
+      })
+      post.title = 'changed my mind'
+      post
+    end
+    post.save!
+    saved_locales = post.translations.map(&:locale)
+    assert saved_locales.include? :it
+  end
+
 end


### PR DESCRIPTION
[This line](https://github.com/svenfuchs/globalize3/blob/master/lib/globalize/active_record/instance_methods.rb#L51) was introduced to fix #65, but it's too generic, and causes still-to-be-saved translations that are not in the current locale to be erroneously deleted.

I've prepared a failing test for this.
