### PR TITLE
Update lib/globalize/active_record/migration.rb

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -144,12 +144,12 @@ module Globalize
 
         def translation_index_name
           index_name = "index_#{translations_table_name}_on_#{table_name.singularize}_id"
-          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"
+          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"[0, 29]
         end
 
         def translation_locale_index_name
           index_name = "index_#{translations_table_name}_on_locale"
-          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"
+          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"[0, 29]
         end
 
         def clear_schema_cache!


### PR DESCRIPTION
Oracle only supports a field name length of 30 chars, there might be database systems that are even more restrictive.
The best way might be to trim the index name to the connection.index_name_length - but correct me if I am wrong?
 
