### PR TITLE
Fix class_name in belongs_to when model is namespaced

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -45,7 +45,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to name.underscore.gsub('/', '_').to_sym
+          klass.belongs_to name.underscore.gsub('/', '_').to_sym, :class_name => self.name
           klass
         end
       end


### PR DESCRIPTION
In refinerycms, page model is translated, but it's namespaced as Refinery::Page. If I load Refinery::Page::Translation and try to get the refinery_page, I get:

> Refinery::Page::Translation.first.refinery_page
> NameError: uninitialized constant Refinery::Page::Translation::RefineryPage

Redefining association to set right class name, it works:

> Refinery::Page::Translation.belongs_to 'refinery_page', :class_name => Refinery::Page.name
> Refinery::Page::Translation.first.refinery_page
