### PR TITLE
Do not hit database each time missing translation requested

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -135,7 +135,7 @@ module Globalize
         unless @translation_caches[locale]
           # Fetch translations from database as those in the translation collection may be incomplete
           _translation = translations.detect{|t| t.locale.to_s == locale.to_s}
-          _translation ||= translations.with_locale(locale).first
+          _translation ||= translations.with_locale(locale).first unless translations.loaded?
           _translation ||= translations.build(:locale => locale)
           @translation_caches[locale] = _translation
         end


### PR DESCRIPTION
That patch fixes problem with excessive database queries for missing translations, but unfortunately breaks one test:

```
  1) Failure:
test_translation_for_ignores_with_translations_scope(Globalize3Test) [/Users/akhkharu/projects/gems/globalize3/test/globalize3_test.rb:157]:
<"title en"> expected but was
<nil>.
```

I have not found an easy way to fix it thus far.
