### PR TITLE
Failing test showing problem in issue #184

### DIFF
--- a/test/data/models.rb
+++ b/test/data/models.rb
@@ -123,3 +123,9 @@ end
 class Account < ActiveRecord::Base
   translates :notes
 end
+
+class Product < ActiveRecord::Base
+  attr_accessible :name
+  translates :description
+  accepts_nested_attributes_for :translations
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -23,6 +23,16 @@ ActiveRecord::Schema.define do
     t.datetime   :published_at
   end
 
+  create_table :products, :force => true do |t|
+    t.string     :name
+  end
+
+  create_table :product_translations, :force => true do |t|
+    t.string     :locale
+    t.references :product
+    t.string     :description
+  end
+
   create_table :parents, :force => true do |t|
   end
 

--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -21,6 +21,14 @@ class AttributesTest < Test::Unit::TestCase
     assert_equal 1, post.translations.length
   end
 
+  test 'does not save a translation if a model does not have one' do
+    product = Product.create
+    assert_equal 0, product.translations.length
+
+    product.update_attributes({"name" => "Widget X"})
+    assert_equal 0, product.translations.length
+  end
+
   test "attribute_names returns translated and regular attribute names" do
     assert_equal %w(blog_id content title), Post.new.attribute_names.sort & %w(blog_id content title)
   end


### PR DESCRIPTION
I believe this shows a bug that may be related to #184. I'm not able to come up with a test case just yet showing the exact issue I am seeing but this seems to be related. I would imagine that not updating any translated attributes should not create empty translation records in the database, right?
