### PR TITLE
Formtastic inputs for translated attributes don't get type information

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -168,6 +168,10 @@ module Globalize
         translation_caches[::Globalize.locale] = translation.previous_version
       end
 
+      def column_for_attribute name
+        translated_attribute_names.include?(name) ? globalize.send(:column_for_attribute, name) : super
+      end
+
     private
 
       def update(*)

--- a/test/globalize3/attributes_test.rb
+++ b/test/globalize3/attributes_test.rb
@@ -267,4 +267,9 @@ class AttributesTest < Test::Unit::TestCase
     assert_equal '', account.business_name
     assert_equal '', account.notes
   end
+
+  test 'delegates column_for_attribute to translations adapter' do
+    post = Post.new
+    assert_equal post.globalize.send(:column_for_attribute, :title), post.column_for_attribute(:title)
+  end
 end


### PR DESCRIPTION
# The problem

I rendered a form using formtastic for a text attribute (not string). Formtastic displays this as a textarea by default. But this does not work for translated attributes, in this case formtastic displays it as a standard text field rather than a textarea.
# Discussion

To guess type, formtastic relies on ActiveRecord `column_for_type`, however this method returns nil for translated attributes because it's not overridden.
# Workaround

The workaround consists in overriding the `column_for_attribute` call in the ActiveRecord model and calling the corresponding method defined in Globalize::Adapter (it's a protected method so I called it using send).

``` ruby
def column_for_attribute name
    translated_attribute_names.include?(name) ? globalize.send(:column_for_attribute, name) : super
end
```

Should this delegation/override be put inside Globalize ? What do you think about this workaround ?
