### PR TITLE
Improved compatibility with PaperTrail

### DIFF
--- a/lib/globalize/versioning/paper_trail.rb
+++ b/lib/globalize/versioning/paper_trail.rb
@@ -12,8 +12,7 @@ module Globalize
       # Clear the `@globalize` instance method when `dup` is invoked to prevent inappropriate changes to the original copy
       def dup
         obj = super
-        obj.send(:remove_instance_variable, :@globalize) unless obj.instance_variable_get(:@globalize).nil?
-        obj
+        obj.tap { |o| o.send(:remove_instance_variable, :@globalize) } rescue obj
       end
     end
   end


### PR DESCRIPTION
This is my attempt to fix airblade/paper_trail#203.  According to what @floehopper has said in the comments of his pull request, I think this should probably do the trick.  I don't have a ton of experience using the Globalize3 gem, so if someone could proof this, and / or provide a failing test for the scenario he is referencing, that would probably be better than just merging this in.  That being said, this shouldn't break any functionality, and all tests still pass with this implementation.
