### PR TITLE
Fixed index too long error when index_name_length < Digest::SHA1.hexdigest(index_name)

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -159,12 +159,14 @@ module Globalize
 
         def translation_index_name
           index_name = "index_#{translations_table_name}_on_#{table_name.singularize}_id"
-          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"
+          index_name.size < connection.index_name_length ? index_name :
+            "index_#{Digest::SHA1.hexdigest(index_name)}"[0, connection.index_name_length]
         end
 
         def translation_locale_index_name
           index_name = "index_#{translations_table_name}_on_locale"
-          index_name.size < connection.index_name_length ? index_name : "index_#{Digest::SHA1.hexdigest(index_name)}"
+          index_name.size < connection.index_name_length ? index_name :
+            "index_#{Digest::SHA1.hexdigest(index_name)}"[0, connection.index_name_length]
         end
 
         def clear_schema_cache!


### PR DESCRIPTION
[Closes #226]
