### PR TITLE
Unit test for a case described in issue #117 (the changes ware not saved if the model used both paper_trail and globalize3)

### DIFF
--- a/test/data/models/dish.rb
+++ b/test/data/models/dish.rb
@@ -1,0 +1,9 @@
+require 'paper_trail'
+
+class Dish < ActiveRecord::Base
+  belongs_to :restaurant
+  
+  translates :name
+  
+  has_paper_trail
+end

--- a/test/data/models/restaurant.rb
+++ b/test/data/models/restaurant.rb
@@ -1,0 +1,5 @@
+class Restaurant < ActiveRecord::Base
+  has_many :dishes
+  
+  accepts_nested_attributes_for :dishes
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -216,4 +216,23 @@ ActiveRecord::Schema.define do
     t.string  :locale
     t.string  :name
   end
+  
+  create_table :restaurants, :force=>true do |t|
+  end
+  
+  create_table :dishes, :force => true do |t|
+    t.string :name
+    t.integer :restaurant_id
+    t.string :description
+    t.float :price
+  end
+  
+  create_table :dish_translations, :force => true do |t|
+    t.integer :dish_id
+    t.string :locale
+    t.string :name
+    t.string :description
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
+  end
 end

--- a/test/globalize3_test.rb
+++ b/test/globalize3_test.rb
@@ -177,4 +177,23 @@ class Globalize3Test < Test::Unit::TestCase
     m = ModelWithCustomTableName.create(:name => 'Name', :locale => :en)
     assert_translated m, :en, :name, 'Name'
   end
+  
+  
+  test "Persisting changes to a translated model that also uses papertrail" do
+    PaperTrail.enabled = true
+    I18n.locale = :en
+    r = Restaurant.create!
+    d = r.dishes.create!(name: "EN", price: 10.0)        
+    r.reload
+    dattr = {'name' => "PL",
+        'description' => d.description,
+        'price' => d.price,
+        'id' => d.id
+    }
+    I18n.locale = :pl
+    r.update_attributes({'dishes_attributes' => {'0' => dattr } })
+    r.reload
+    assert_equal r.dishes.first.name, "PL"    
+  end
+  
 end

--- a/test/globalize3_test.rb
+++ b/test/globalize3_test.rb
@@ -179,21 +179,21 @@ class Globalize3Test < Test::Unit::TestCase
   end
   
   
-  test "Persisting changes to a translated model that also uses papertrail" do
-    PaperTrail.enabled = true
+  test "persisting changes to a translated model that also uses papertrail" do
+    prev_locale = I18n.locale
     I18n.locale = :en
     r = Restaurant.create!
     d = r.dishes.create!(name: "EN", price: 10.0)        
-    r.reload
-    dattr = {'name' => "PL",
-        'description' => d.description,
-        'price' => d.price,
-        'id' => d.id
+    dattr = {
+      'name' => "PL",
+      'description' => d.description,
+      'price' => d.price,
+      'id' => d.id
     }
     I18n.locale = :pl
     r.update_attributes({'dishes_attributes' => {'0' => dattr } })
-    r.reload
     assert_equal r.dishes.first.name, "PL"    
+    I18n.locale = prev_locale
   end
   
 end

--- a/test/globalize3_test.rb
+++ b/test/globalize3_test.rb
@@ -183,7 +183,7 @@ class Globalize3Test < Test::Unit::TestCase
     prev_locale = I18n.locale
     I18n.locale = :en
     r = Restaurant.create!
-    d = r.dishes.create!(name: "EN", price: 10.0)        
+    d = r.dishes.create!(:name => "EN", :price => 10.0)        
     dattr = {
       'name' => "PL",
       'description' => d.description,


### PR DESCRIPTION
This has been already *fixed* in the newest (github) version of globalize3, but maybe that test will be useful. 

For reference: 
This was failing for me on gem 'globalize3'; Works on gem from github. Also this workaround fixes it: 

```ruby
module PaperTrail
  module Model
    module InstanceMethods

      def initialize_copy(source)
        obj = super(source)
        obj.tap { |o| o.send(:remove_instance_variable, :@globalize) } rescue obj
        obj
      end

    end
  end
end
```