### PR TITLE
Note to drop columns from the parent table after data has been safely migrated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,8 @@ class TranslatePosts < ActiveRecord::Migration
 end
 ```
 
+NOTE: Make sure you drop the translated columns from the parent table after all your data is safely migrated.
+
 ## Versioning with Globalize3
 
 Globalize3 nicely integrates with


### PR DESCRIPTION
As discussed in https://github.com/svenfuchs/globalize3/issues/245, this is a simple attempt at providing a note to delete translated columns from the parent table after the data has been safely migrated. 
