### PR TITLE
fix where_values_hash patch to work with rails4.

### DIFF
--- a/lib/patches/active_record/relation.rb
+++ b/lib/patches/active_record/relation.rb
@@ -8,7 +8,12 @@ module ActiveRecord
           [table_name, _translations_table_name].compact.include? node.left.relation.name
         }
 
-        Hash[equalities.map { |where| [where.left.name, where.right] }].with_indifferent_access
+        binds = Hash[bind_values.find_all(&:first).map { |column, v| [column.name, v] }]
+
+        Hash[equalities.map { |where|
+          name = where.left.name
+          [name, binds.fetch(name.to_s) { where.right } ]
+        }].with_indifferent_access
       end
     end
   end


### PR DESCRIPTION
This brings the number of test failures down from 13 to just three.
