### PR TITLE
fix typo (name a variable, not :name a symbol) and change locale assignment to boolean

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -84,7 +84,7 @@ module Globalize
 
       def translated_attributes
         translated_attribute_names.inject({}) do |attributes, name|
-          if self.respond_to?(:name) && Globalize.locale = I18n.default_locale
+          if self.respond_to?(name) && Globalize.locale == I18n.default_locale
             attributes.merge(name.to_s => self.send(name))
           else
             attributes.merge(name.to_s => translation.send(name))


### PR DESCRIPTION
If I'm understanding this code correctly, this should be checking that the model responds to `name` (an attribute), not `:name` (a symbol), which doesn't make any sense in this context. Also the latter half surely is a boolean check to see whether `Globalize.locale` is `I18n.locale`, and not an assignment, right?

In any case, this change brings the failure count on the `rails4` branch down from 3 to just 1. Actually all three previous failures are gone and this introduces a [new one](https://github.com/svenfuchs/globalize3/blob/rails4/test/globalize3/attributes_test.rb#L197) (see below).

(@simi you wrote the code that I changed here and also the [test](https://github.com/svenfuchs/globalize3/blob/rails4/test/create_row_test.rb) that was failing because of it, could you have a look at this?)
