### PR TITLE
simplify/refactor save_translations -- all passing tests continue to pass.

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -34,17 +34,11 @@ module Globalize
       end
 
       def save_translations!
-        existing_translations_by_locale = {}
-        record.translations.each do |t|
-          existing_translations_by_locale[t.locale.to_s] = t
-        end
+        existing_translations_by_locale = Hash[record.translations.map { |t| [ t.locale, t ] }]
 
         stash.each do |locale, attrs|
           if attrs.any?
-            locale_str = locale.to_s
-
-            translation = existing_translations_by_locale[locale_str] ||
-              record.translations.find_or_initialize_by_locale(locale_str)
+            translation = existing_translations_by_locale[locale] || record.translations.build(locale: locale.to_s)
             attrs.each { |name, value| translation[name] = value }
             translation.save!
           end


### PR DESCRIPTION
While trying to fix the remaining failing test, I simplified `save_translations` a bit.

I don't see why we would need `find_or_initialize_by_locale` here, since if there existed a translation for a locale we would already have it in the `existing_translations_by_locale` hash.
