### PR TITLE
add support for scope option on uniqueness validation for translated attributes

### DIFF
--- a/test/data/models/scoped_validatee.rb
+++ b/test/data/models/scoped_validatee.rb
@@ -1,0 +1,3 @@
+class ScopedValidatee < ActiveRecord::Base
+  translates :string, :scope_string
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -81,6 +81,17 @@ ActiveRecord::Schema.define do
     t.string     :string
   end
 
+  create_table :scoped_validatees, :force => true do |t|
+    t.integer :integer, :another_integer
+  end
+
+  create_table :scoped_validatee_translations, :force => true do |t|
+    t.references :scoped_validatee
+    t.string     :locale
+    t.string     :string
+    t.string     :scope_string
+  end
+
   create_table :users, :force => true do |t|
     t.string   :email
     t.datetime :created_at


### PR DESCRIPTION
I submitted a pull request for this earlier in #139, but there was a problem supporting Rails 3.0. Since we're not supporting 3.0 in the rails4 branch, I thought I'd resubmit it (with updates to make it work with minispec, etc.).

The tests should be self-explanatory but let me know if anything doesn't make sense. (I haven't looked at this for a while so I'll have to refresh my memory first though...)

Oh, and all tests pass (except the one that is still failing).
