### PR TITLE
do not autosave translation to avoid additional db update when translation is cached

### DIFF
--- a/create_row_test.rb
+++ b/create_row_test.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+require File.expand_path('../test_helper', __FILE__)
+
+module ActiveRecord
+  class Updater
+    cattr_accessor :query_count, :queries
+
+    FILTER = [/UPDATE/]
+
+    def call(name, start, finish, message_id, values)
+      # FIXME: this seems bad. we should probably have a better way to indicate
+      # the query was cached
+      unless 'CACHE' == values[:name]
+        self.class.query_count += 1 if FILTER.any? { |r| values[:sql] =~ r }
+        self.class.queries << values[:sql] if FILTER.any? { |r| values[:sql] =~ r }
+      end
+    end
+  end
+end
+
+class CreateRowTest < Test::Unit::TestCase
+  def setup
+    ActiveSupport::Notifications.subscribe('sql.active_record', ActiveRecord::Updater.new)
+    ActiveRecord::Updater.query_count = 0
+    ActiveRecord::Updater.queries = []
+  end
+
+  def teardown
+    ActiveSupport::Notifications.unsubscribe('sql.active_record')
+  end
+
+  test "does not perform update when saving with cached translation" do
+    p = Page.new(:title => 'title v1')
+    p.translation.title
+    p.save!
+    assert_equal 0, ActiveRecord::Updater.query_count
+  end
+end

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -66,7 +66,8 @@ module Globalize
         has_many :translations, :class_name  => translation_class.name,
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
-                                :extend      => HasManyExtensions
+                                :extend      => HasManyExtensions,
+                                :autosave    => false
 
         after_create :save_translations!
         after_update :save_translations!


### PR DESCRIPTION
I've pulled over the [`create_row_test`](https://github.com/svenfuchs/globalize3/blob/rails4/test/create_row_test.rb) from the rails4 branch and trimmed it down to a single test that checks whether an update is performed when saving a record with a cached translation.

The problem is easy to solve: just pass an `:autosave => false` option to `has_many` when creating the translations association.

From the [docs](http://api.rubyonrails.org/classes/ActiveRecord/AutosaveAssociation.html):

> Note that autosave: false is not same as not declaring :autosave. When the :autosave option is not present then new association records are saved but the updated association records are not saved.

So the problem is that when a translation is cached on a new instance, rails will save the translation once when saving the record but with a nil value for translated attributes, then update it in `save_translations` with the translated attribute value. It should just save it in one step.

I don't see any other failures so I think this is just something that has been missed because it's not obvious.

If this is okay I'll merge it to the rails4 branch as well.
