### PR TITLE
ensure Globalize.with_locale resets the locale to its previous value

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -19,9 +19,12 @@ module Globalize
 
     def with_locale(locale, &block)
       previous_locale = read_locale
-      set_locale(locale)
-      result = yield(locale)
-      set_locale(previous_locale)
+      begin
+        set_locale(locale)
+        result = yield(locale)
+      ensure
+        set_locale(previous_locale)
+      end
       result
     end
 

--- a/test/globalize3/locale_test.rb
+++ b/test/globalize3/locale_test.rb
@@ -53,6 +53,17 @@ class LocaleTest < Test::Unit::TestCase
     assert_equal :en, Globalize.locale
   end
 
+  test 'with_locale resets the locale to the previous one even if an exception occurs in the block' do
+    assert_equal :en, Globalize.locale
+    begin
+      Globalize.with_locale :de do |locale|
+        raise
+      end
+    rescue Exception
+    end
+    assert_equal :en, Globalize.locale
+  end
+
   test 'with_locales calls block once with each locale given temporarily set' do
     locales = Globalize.with_locales :en, [:de, :fr] do |locale|
       assert_equal locale, Globalize.locale


### PR DESCRIPTION
If the block given to <tt>Globalize.with_locale</tt> raises an exception the locale is not reset:

```
> puts Globalize.locale
en
> Globalize.with_locale(:ja) { puts Globalize.locale }
ja
> puts Globalize.locale
en

> Globalize.with_locale(:ja) { puts Globalize.locale; raise "WTF!" }
ja
RuntimeError: WTF!
> puts Globalize.locale
ja
```
