### PR TITLE
Globalize gets a logo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# Globalize [![Build Status](https://travis-ci.org/globalize/globalize.png?branch=master)](https://travis-ci.org/globalize/globalize) [![Code Climate](https://codeclimate.com/github/globalize/globalize.png)](https://codeclimate.com/github/globalize/globalize)
+![Globalize](http://globalize.github.io/globalize/images/globalize.png)
+
+[![Build Status](https://travis-ci.org/globalize/globalize.png?branch=master)](https://travis-ci.org/globalize/globalize) [![Code Climate](https://codeclimate.com/github/globalize/globalize.png)](https://codeclimate.com/github/globalize/globalize)
 
 Globalize builds on the [I18n API in Ruby on Rails](http://guides.rubyonrails.org/i18n.html)
 to add model translations to ActiveRecord models.


### PR DESCRIPTION
![globalize](http://globalize.github.io/globalize/images/globalize.png)

I'm creating a pull request for this since there wasn't general agreement. Ref: https://twitter.com/parndt/status/391422841251315712

Here's the font: https://www.google.com/fonts/specimen/Righteous I like it, but there was some disagreement:

"awesome"
https://twitter.com/_tomash/status/391190374930079746

"not a huge fan"
https://twitter.com/svenfuchs/status/391189803485896704

I previously had another background:

![globalize](http://globalize.github.io/globalize/images/logo-large.png)

From here: https://upload.wikimedia.org/wikipedia/commons/e/e4/Globe.png

but swapped it for a NASA photo.

I'm okay with anything, even scrapping this proposal entirely, or switching the background for something else. But I think we should have something. Comments/suggestions?

If anyone knows a real designer who wants to create something original for us, that would be great too (I am _not_ a designer and do not pretend to be one...)

cc @parndt @tomash @svenfuchs
