### PR TITLE
use AR::Relation#extending! method to override query methods, much simpler

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -57,8 +57,6 @@ module Globalize
         include InstanceMethods
         extend  ClassMethods, Migration
 
-        setup_translated_relations!
-
         translation_class.table_name = options[:table_name]
 
         has_many :translations, :class_name  => translation_class.name,
@@ -80,26 +78,6 @@ module Globalize
             delegate :version, :versions, :to => :translation
           end
         end
-      end
-
-      # In order to allow queries on translated attributes in associations, we have to
-      # include QueryMethods in CollectionProxy and AssociationRelation. So as not to
-      # pollute the original classes, we use delegated classes specific to this model.
-      def setup_translated_relations!
-        delegated_relation_classes.each do |klass|
-          (klass.send :relation_class_for, self).send :include, QueryMethods if klass.respond_to?(:relation_class_for, true)
-        end
-      end
-
-      def delegated_relation_classes
-        klasses = []
-        if ::ActiveRecord.const_defined?('Associations') && ::ActiveRecord::Associations.const_defined?('CollectionProxy')
-          klasses << ::ActiveRecord::Associations::CollectionProxy
-        end
-        if ::ActiveRecord.const_defined?('AssociationRelation')
-          klasses << ::ActiveRecord::AssociationRelation
-        end
-        klasses
       end
     end
 

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -131,20 +131,7 @@ module Globalize
       # of ActiveRecord::Relation with custom finder methods for translated
       # attributes.
       def relation
-        relation = globalize_relation_class.new(self, arel_table)
-
-        if finder_needs_type_condition?
-          relation.where(type_condition).create_with(inheritance_column.to_sym => sti_name)
-        else
-          relation
-        end
-      end
-
-      def globalize_relation_class
-        @relation_class ||= Class.new(::ActiveRecord::Relation).tap do |klass|
-          klass.send :include, QueryMethods
-          const_set('GlobalizeActiveRecordRelation', klass)
-        end
+        super.extending!(QueryMethods)
       end
 
       protected


### PR DESCRIPTION
Just creating a pull request in case we need to discuss this in the future. TravisCI tests pass so will merge.

cc @norman this might be a better way to do it in FriendlyId as well, works with associations and doesn't require ugly monkeypatching. re: norman/friendly_id#452 (Doesn't seem rails/rails#13220 is going to be taken up but this works just as well.)
