### PR TITLE
Fix issue where globalize breaks has_many through

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -52,7 +52,7 @@ module Globalize
       end
 
       def parse_translated_conditions(opts)
-        if opts.is_a?(Hash) && (keys = opts.symbolize_keys.keys & translated_attribute_names).present?
+        if opts.is_a?(Hash) && respond_to?(:translated_attribute_names) && (keys = opts.symbolize_keys.keys & translated_attribute_names).present?
           opts = opts.dup
           keys.each { |key| opts[translated_column_name(key)] = opts.delete(key) || opts.delete(key.to_s) }
           opts

--- a/test/data/models/attachment.rb
+++ b/test/data/models/attachment.rb
@@ -1,0 +1,4 @@
+class Attachment < ActiveRecord::Base
+  belongs_to :post
+end
+

--- a/test/data/models/blog.rb
+++ b/test/data/models/blog.rb
@@ -1,3 +1,5 @@
 class Blog < ActiveRecord::Base
   has_many :posts, proc { order('posts.id ASC') }
+  has_many :attachments, through: :posts
+  has_many :translated_comments, through: :posts
 end

--- a/test/data/models/post.rb
+++ b/test/data/models/post.rb
@@ -3,4 +3,6 @@ class Post < ActiveRecord::Base
   validates_presence_of :title
   scope :with_some_title, proc { { :conditions => { :title => 'some_title' } } }
   accepts_nested_attributes_for :translations
+  has_many :attachments
+  has_many :translated_comments
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -228,4 +228,9 @@ ActiveRecord::Schema.define do
     t.string  :locale
     t.string  :name
   end
+
+  create_table "attachments" do |t|
+    t.references :post
+    t.string :file_type
+  end
 end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -210,6 +210,11 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       post = blog.posts.create(:title => 'a title')
       blog.posts.create(:title => 'another title')
       assert_equal [post], blog.posts.where(:title => 'a title').load
+
+      comment = post.translated_comments.create(content: "something")
+      post.translated_comments.create(content: "something else")
+      assert_equal [comment], post.translated_comments.where(content: "something").load
+      assert_equal [comment], blog.translated_comments.where(content: "something").load
     end
 
     it 'parses translated attributes in chained relations' do
@@ -218,6 +223,14 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       blog.posts.create(:title => 'a title', :content => 'bar')
       result = blog.posts.where(:content => 'foo').where(:title => 'a title').load
       assert_equal [post], result
+    end
+
+    it 'finds records that is not translated' do
+      blog = Blog.create
+      post = blog.posts.create(:title => 'a title')
+      attachment = post.attachments.create(file_type: "image")
+      assert_equal attachment, post.attachments.where(file_type: "image").first
+      assert_equal attachment, blog.attachments.where(file_type: "image").first
     end
   end
 end


### PR DESCRIPTION
Any time you were using where on a has many through association
with a model that doesn't use translates, an exception was being thrown
because translated_attribute_names wasn't defined
