### PR TITLE
fix: always extract options from attr_names

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -2,8 +2,9 @@ module Globalize
   module ActiveRecord
     module ActMacro
       def translates(*attr_names)
+        options = attr_names.extract_options!
         # Bypass setup_translates! if the initial bootstrapping is done already.
-        setup_translates!(attr_names.extract_options!) unless translates?
+        setup_translates!(options) unless translates?
 
         # Add any extra translatable attributes.
         attr_names = attr_names.map(&:to_sym)


### PR DESCRIPTION
This fix situation when we are passing some options in attr_names, method `translates?` returns `true` and then next line fail on `undefined method `to_sym' for {...}:Hash`

m.
