### PR TITLE
Don't create translation record for default_locale on save

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -46,7 +46,7 @@ module Globalize
         return super(name) unless options[:translated]
 
         if name == :locale
-          self.try(:locale).presence || self.translation.locale
+          self.try(:locale).presence || Globalize.locale
         elsif self.class.translated?(name)
           if (value = globalize.fetch(options[:locale] || Globalize.locale, name))
             value

--- a/test/data/models/artwork.rb
+++ b/test/data/models/artwork.rb
@@ -1,0 +1,4 @@
+class Artwork < ActiveRecord::Base
+  translates :title
+  accepts_nested_attributes_for :translations
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -221,4 +221,13 @@ ActiveRecord::Schema.define do
     t.references :post
     t.string :file_type
   end
+
+  create_table :artworks, :force => true do |t|
+  end
+
+  create_table :artwork_translations, :force => true do |t|
+    t.string     :locale
+    t.references :artwork
+    t.string     :title, null: false
+  end
 end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -258,4 +258,43 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       assert_equal attachment, blog.attachments.where(file_type: "image").first
     end
   end
+
+  describe "without a record for default locale" do
+    before do
+      @artwork = Artwork.new
+    end
+
+    it "returns default locale without creating a record for it" do
+      @artwork.translations.build(locale: :de, title: "Titel")
+      locale = @artwork.read_attribute(:locale)
+
+      assert_equal :en, locale
+      assert_equal 1, @artwork.translations.size
+    end
+
+    it "doesn't create translation for default locale on save" do
+      @artwork.translations.build(locale: :de, title: "Titel")
+      @artwork.save
+
+      assert_equal 1, @artwork.translations.count
+      assert_equal :de, @artwork.translations.first.locale
+    end
+
+    it "doesn't create any translation on save" do
+      @artwork.save
+
+      assert_equal 0, @artwork.translations.count
+    end
+
+    it "creates a translation for default locale after the assignment of translated attributes" do
+      @artwork.save
+      @artwork.title = "Title"
+      @artwork.save
+
+      assert_equal 1, @artwork.translations.count
+      assert_equal :en, @artwork.translations.first.locale
+      assert_equal "Title", @artwork.title
+    end
+
+  end
 end


### PR DESCRIPTION
I want to allow users to create localized pages for a specific locale, excluding default locale.
That way I can have a czech-specific page only on the czech version of a site.
But I can't do that because when I'm trying to save a new `Page` record with a `Page::Translation` association (`locale == :cz`), rails gives me a validation error, because globalize has added another association with `locale == :en`.

I'm using `rails_admin` and its default field for has_many associations. 

I think that my problem starts  inside `save` method.

``` ruby
      def save(*)
        Globalize.with_locale(read_attribute(:locale) || I18n.default_locale) do
          super
        end
      end
```

In particular, this part in `read_attribute`:

``` ruby
        if name == :locale
          self.try(:locale).presence || self.translation.locale
```

Which leads to `translation` method:

``` ruby
translation_for(::Globalize.locale)
```

As a result, `translation_for` builds an empty translation for default `::Globalize.locale` locale.

---

I think that `read_attribute(:locale)` could skip creating default translation record, because in that particular case it only uses it to get its locale, that is equal to `Globalize.locale` anyway.
I ran `rake test` on this branch and on the branch with merged _before_callbacks_ (it's called _combined_) and there's no new errors. 
