### PR TITLE
Add available_locales method

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -134,6 +134,11 @@ module Globalize
         translations_by_locale(&:"#{name}")
       end
 
+      # Get available locales from translations association, without a separate distinct query
+      def available_locales
+        translations.map(&:locale).uniq
+      end
+
       def globalize_fallbacks(locale)
         Globalize.fallbacks(locale)
       end


### PR DESCRIPTION
Basically, it's doing the same as deletaged  `translated_locales` method on objects.
But it doesn't use a separate DISTINCT query in comparison.

I think it's a useful method, because most of the time I already have translations in the memory and I can use them.
