### PR TITLE
Fix save issue when updating multiple locales at once

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -44,21 +44,17 @@ module Globalize
             options = {:locale => options}
           end
           options = {:locale => Globalize.locale}.merge(options)
-          
+
           # Dirty tracking, paraphrased from
           # ActiveRecord::AttributeMethods::Dirty#write_attribute.
           name_str = name.to_s
-          if attribute_changed?(name_str)
-            # If there's already a change, delete it if this undoes the change.
-            old = changed_attributes[name_str]
-            changed_attributes.delete(name_str) if value == old
-          else
+          unless attribute_changed?(name_str)
             # If there's not a change yet, record it.
             old = globalize.fetch(options[:locale], name)
             old = old.clone if old.duplicable?
             changed_attributes[name_str] = old if value != old
           end
-          
+
           globalize.write(options[:locale], name, value)
         else
           super(name, value)

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -77,21 +77,4 @@ class DirtyTrackingTest < Test::Unit::TestCase
     post.save
   end
 
-  test 'dirty tracking does not track fields with identical values' do
-    post = Post.create(:title => 'title', :content => 'content')
-    assert_equal [], post.changed
-    
-    post.title = 'title'
-    assert_equal [], post.changed
-    
-    post.title = 'changed title'
-    assert_equal({ 'title' => ['title', 'changed title'] }, post.changes)
-    
-    post.title = 'doubly changed title'
-    assert_equal({ 'title' => ['title', 'doubly changed title'] }, post.changes)
-    
-    post.title = 'title'
-    assert_equal [], post.changed
-  end
-
 end


### PR DESCRIPTION
We had update record issues in our admin interface.

We basically update title_en, title_ru, title_lv with single form (using globalize-accessors).
In various conditions this used to fail, because of line 54.

I wanted to update globalize and globalize-accessors to be able to track changes for each locale, but didn't find easy way to do this in reasonable amount of time.

Anyway, what do you think about this patch?
Is there anything I can/need to do to get it merged?

If you need more detailed example of failing scenario let me know.