### PR TITLE
Replace after_ callbacks with before_

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -75,10 +75,10 @@ module Globalize
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
-                                :autosave    => false
+                                :autosave    => true
 
-        after_create :save_translations!
-        after_update :save_translations!
+        before_create :save_translations!
+        before_update :save_translations!
       end
     end
 

--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -38,8 +38,6 @@ module Globalize
           translation = record.translations_by_locale[locale] ||
                         record.translations.build(locale: locale.to_s)
           attrs.each { |name, value| translation[name] = value }
-          ensure_foreign_key_for(translation)
-          translation.save!
         end
 
         reset
@@ -50,12 +48,6 @@ module Globalize
       end
 
       protected
-
-      # Sometimes the translation is initialised before a foreign key can be set.
-      def ensure_foreign_key_for(translation)
-        # AR >= 4.1 reflections renamed to _reflections
-        translation[translation.class.reflections[:globalized_model].foreign_key] = record.id
-      end
 
       def type_cast(name, value)
         return value.presence unless column = column_for_attribute(name)

--- a/test/data/models/artwork.rb
+++ b/test/data/models/artwork.rb
@@ -1,0 +1,4 @@
+class Artwork < ActiveRecord::Base
+  translates :title
+  accepts_nested_attributes_for :translations
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -221,4 +221,13 @@ ActiveRecord::Schema.define do
     t.references :post
     t.string :file_type
   end
+
+  create_table :artworks, :force => true do |t|
+  end
+
+  create_table :artwork_translations, :force => true do |t|
+    t.string     :locale
+    t.references :artwork
+    t.string     :title, null: false
+  end
 end


### PR DESCRIPTION
Beginning of discussion: https://github.com/globalize/globalize/issues/325

I replaced after_create/after_update with before_create/before_update and set autosave: true.
Now we don't need to explicitly call translations.save inside save_translations!, because autosave takes care of it for us.
Test results haven't changed (192 tests, 1 skips).

Also I added a couple of tests for the current null: false case.

I merged my current branch into the previously created before_callbacks branch and I'm not sure that it would give the best git log. Can anybody validate it for me? (I can fork globalize again and reapply all changes by hand, if it's needed)