### PR TITLE
added inverse_of to the relationships

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -74,7 +74,8 @@ module Globalize
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
-                                :autosave    => true
+                                :autosave    => true,
+                                :inverse_of  => :globalized_model
 
         before_create :save_translations!
         before_update :save_translations!

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -48,7 +48,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations
           klass
         end
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -84,7 +84,7 @@ module Globalize
           options[locale].each do |key, value|
             translation.send :"#{key}=", value
           end
-          translation.save
+          translation.save if persisted?
         end
         globalize.reset
       end


### PR DESCRIPTION
Hi everyone,

I added the :inverse_of to the relationships between the translations and the globalized_model. This way you can for example access the globalized_model from the translations even before the translated model is saved.

I for example have a model like this

``` ruby
class Page

  translates :path, :title
  accepts_nested_attributes_for :translations

  class Translation < Globalize::ActiveRecord::Translation

    before_validation :calculate_strings

    def calculate_strings
      # do something depending on globalized_model
    end
  end
end
```

which will currently not work when saving new pages.
