### PR TITLE
Fixed Carrierwave(probably other gems too) integration issue

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -37,7 +37,10 @@ module Globalize
         stash.reject {|locale, attrs| attrs.empty?}.each do |locale, attrs|
           translation = record.translations_by_locale[locale] ||
                         record.translations.build(locale: locale.to_s)
-          attrs.each { |name, value| translation[name] = value }
+          attrs.each do |name, value|
+            method_name = "#{name}="
+            translation.public_send(method_name, value) if translation.respond_to? method_name
+          end
           ensure_foreign_key_for(translation)
           translation.save!
         end


### PR DESCRIPTION
Hey guys,

Recently I have tried to integrate carrierwave with globalize and faced a problem when trying to translate fields with mounted Carrierwave Uploader. The uploader is not triggered when saving the object, so I have decided to look deeper into globalize gem. It looks like AR Adapter is operating on too low api level when assigning translated values. Assigining via

``` ruby
attrs.each { |name, value| translation[name] = value }
```

skips Carrierwave(and probably other gems) uploader behavior. I have written fix for this, which uses accessor methods for assignment rather than low level hash assignment. Now everything works fine and do not need any hacking around.
