### PR TITLE
Fixes a problem with dup and instance variables

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -99,6 +99,8 @@ module Globalize
       end
 
       def initialize_dup(other)
+        @globalize = nil
+        @translation_caches = nil
         super
         other.each_locale_and_translated_attribute do |locale, name|
           globalize.write(locale, name, other.globalize.fetch(locale, name) )

--- a/test/globalize/dup_test.rb
+++ b/test/globalize/dup_test.rb
@@ -23,6 +23,27 @@ class DupTest < MiniTest::Spec
     end
   end
 
+  describe 'dup leaves original model alone' do
+
+    it 'should not update the existing model' do
+      original = saved_post
+      original_title = original.title
+
+      dupd = original.dup.tap do |new_model|
+        new_model.title = "Foo New Model"
+      end
+      original.translations.each do |translation|
+        dupd.translations << translation.dup
+      end
+      dupd.save!
+
+      original.reload
+      assert_equal "Foo New Model", dupd.title
+      assert_equal original_title, original.title
+    end
+
+  end
+
 
   private
 


### PR DESCRIPTION
Fixes a problem where after dup the dup'd model and the original model share a translation instance, which means that if you mutate a translated field on the dup and save it, the original becomes a clone of the dup.

We were running in to this in our efforts to use [spree](https://github.com/spree/spree_i18n), so there's at least one major implementation that is effected.

Thanks in advance!
