### PR TITLE
Fix crash due to removal of #reflections rails4.1

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -53,7 +53,7 @@ module Globalize
 
       def ensure_foreign_key_for(translation)
         # Sometimes the translation is initialised before a foreign key can be set.
-        translation[translation.reflections[:globalized_model].foreign_key] = record.id
+        translation[translation._reflections[:globalized_model].foreign_key] = record.id
       end
 
       def type_cast(name, value)


### PR DESCRIPTION
With rails 4.1, any call to #ensure_foreign_key_for will crash with "undefined method `reflections' for #<ModelName::Translation:…"

See this discussion for the simple fix: https://github.com/rails/rails/pull/15300
