### PR TITLE
Fix compatibility with activerecord 4.1.2.rc1

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -42,7 +42,7 @@ module Globalize
         end
       end
 
-      def where_values_hash
+      def where_values_hash(*args)
         equalities = respond_to?(:with_default_scope) ? with_default_scope.where_values : where_values
         equalities = equalities.grep(Arel::Nodes::Equality).find_all { |node|
           node.left.relation.name == translations_table_name


### PR DESCRIPTION
`where_values_hash` now taskes the reflection name as an argument, so we need to update the monkey patch. This should be fully backwards compatible.
