### PR TITLE
Add UUID support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ NOTES
 .DS_Store
 .bundle
 Gemfile.lock
-globalize.iml
 .rvmrc
 *.sw*
 *.gem

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ NOTES
 .DS_Store
 .bundle
 Gemfile.lock
+globalize.iml
 .rvmrc
 *.sw*
 *.gem

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -67,9 +67,8 @@ module Globalize
         end
 
         def create_translation_table(options = {})
-          if options[:use_uuid] == true
-            connection.create_table(translations_table_name, id: false) do |t|
-              t.uuid :id, primary: true
+          if options[:use_uuid]
+            connection.create_table(translations_table_name, id: :uuid) do |t|
               t.uuid (table_name.sub(/^#{table_name_prefix}/, '').singularize + "_id"), :null => false
               t.string :locale, :null => false
               t.timestamps

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -70,7 +70,7 @@ module Globalize
           if options[:use_uuid] == true
             connection.create_table(translations_table_name, id: false) do |t|
               t.uuid :id, primary: true
-              t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false
+              t.uuid (table_name.sub(/^#{table_name_prefix}/, '').singularize + "_id"), :null => false
               t.string :locale, :null => false
               t.timestamps
             end

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -30,7 +30,7 @@ module Globalize
           complete_translated_fields if fields.blank?
           validate_translated_fields
 
-          create_translation_table
+          create_translation_table(options)
           add_translation_fields!(fields, options)
           create_translations_index
           clear_schema_cache!
@@ -66,11 +66,20 @@ module Globalize
           end
         end
 
-        def create_translation_table
-          connection.create_table(translations_table_name) do |t|
-            t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false
-            t.string :locale, :null => false
-            t.timestamps
+        def create_translation_table(options = {})
+          if options[:use_uuid] == true
+            connection.create_table(translations_table_name, id: false) do |t|
+              t.uuid :id, primary: true
+              t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false
+              t.string :locale, :null => false
+              t.timestamps
+            end
+          else
+            connection.create_table(translations_table_name) do |t|
+              t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false
+              t.string :locale, :null => false
+              t.timestamps
+            end
           end
         end
 

--- a/lib/globalize/active_record/translation.rb
+++ b/lib/globalize/active_record/translation.rb
@@ -5,7 +5,7 @@ module Globalize
       validates :locale, :presence => true
       self.primary_key = :id
 
-      before_save :generate_uuid
+      before_save :generate_uuid_if_necessary
 
       class << self
         # Sometimes ActiveRecord queries .table_exists? before the table name
@@ -37,8 +37,9 @@ module Globalize
       end
 
       private
-      def generate_uuid
-        unless self.id
+      def generate_uuid_if_necessary
+        unless self.id &&
+               self.class.column_types[self.class.primary_key].type == :uuid
           begin
             uuid = SecureRandom.uuid
             self.id = uuid

--- a/lib/globalize/active_record/translation.rb
+++ b/lib/globalize/active_record/translation.rb
@@ -3,7 +3,6 @@ module Globalize
     class Translation < ::ActiveRecord::Base
 
       validates :locale, :presence => true
-      self.primary_key = :id
 
       before_save :generate_uuid_if_necessary
 

--- a/lib/globalize/active_record/translation.rb
+++ b/lib/globalize/active_record/translation.rb
@@ -3,6 +3,9 @@ module Globalize
     class Translation < ::ActiveRecord::Base
 
       validates :locale, :presence => true
+      self.primary_key = :id
+
+      before_save :generate_uuid
 
       class << self
         # Sometimes ActiveRecord queries .table_exists? before the table name
@@ -31,6 +34,16 @@ module Globalize
 
       def locale=(locale)
         write_attribute :locale, locale.to_s
+      end
+
+      private
+      def generate_uuid
+        unless self.id
+          begin
+            uuid = SecureRandom.uuid
+            self.id = uuid
+          end until self.class.where(id: uuid).length == 0
+        end
       end
     end
   end


### PR DESCRIPTION
I've added support for using UUIDs in the translation tables when the model that should be translated uses UUIDs instead of IDs itself. Therefore I have extended create_translation_table with an option "use_uuid".