### PR TITLE
Fix persisting translations with presence validation of translated fields.

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -46,7 +46,7 @@ module Globalize
         return super(name) unless options[:translated]
 
         if name == :locale
-          self.try(:locale).presence || self.translation.locale
+          self.try(:locale).presence || Globalize.locale
         elsif self.class.translated?(name)
           if (value = globalize.fetch(options[:locale] || Globalize.locale, name))
             value

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -230,5 +230,29 @@ class GlobalizeTest < MiniTest::Spec
         end
       end
     end
+
+    describe 'with presence validation of translated fields' do
+      before do
+        Post::Translation.instance_eval do
+          def self.validate
+            errors.add(:base, 'can\'t be blank') if self.title.blank?
+          end
+        end
+      end
+
+      after do
+        Post::Translation.instance_eval do
+          def self.validate
+            true
+          end
+        end
+      end
+
+      it 'saves translations successfully' do
+        count = Post::Translation.count
+        Post.create(:title => 'title 1')
+        assert_equal Post::Translation.count, count + 1
+      end
+    end
   end
 end


### PR DESCRIPTION
If you added additional validations of translated fields to your translation model, you are not able to persist model and its translations because of validation errors.

```ruby
class Post::Translation
  validates :title, presence: true
end
```

Validation errors appear on empty translation which is built when `:locale` attribute is fetched on `save` (inside `#read_attribute` method).
This pull-request fixes such issues.