### PR TITLE
Add locale to ActiveRecord#cache_key

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -153,6 +153,10 @@ module Globalize
 
         globalize.send(:column_for_attribute, name)
       end
+      
+      def cache_key
+        super + '-' + Globalize.locale.to_s
+      end
 
     protected
 

--- a/test/globalize/cache_key_test.rb
+++ b/test/globalize/cache_key_test.rb
@@ -1,0 +1,16 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class CacheKeyTest < MiniTest::Spec
+  describe '#cache_key' do
+    it 'suffixes locale to the cache key' do
+      puts 'got into my test'
+      post = Post.create(:title => 'Title', :locale => :en)
+      post.update_attributes(:title => 'Titel', :locale => :de)
+
+      Globalize.locale = :en
+      assert_match /-en$/, post.cache_key
+      Globalize.locale = :de
+      assert_match /-de$/, post.cache_key
+    end
+  end
+end


### PR DESCRIPTION
Problem:  The following code will pick up the fragment for the locale it was first cached in, even if Globalize.locale changes. 

``` erb
<% cache @blog_post %>
  <%= @blog_post.title %>
<% end %>
```

Making ActiveRecord#cache_key sensitive to Globalize.locale gives a workaround / resolution to the problem so that rails caching can continue to work out of the box when using Globalize. 
