### PR TITLE
keep object changed when re-setting to old value

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -30,7 +30,7 @@ module Globalize
         if attribute_changed?(name_str)
           # If there's already a change, delete it if this undoes the change.
           old = changed_attributes[name_str]
-          changed_attributes.delete(name_str) if value == old
+          # changed_attributes.delete(name_str) if value == old
         else
           # If there's not a change yet, record it.
           old = globalize.fetch(options[:locale], name)

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -38,8 +38,8 @@ class DirtyTrackingTest < MiniTest::Spec
       post.title = 'doubly changed title'
       assert_equal({ 'title' => ['title', 'doubly changed title'] }, post.changes)
 
-      post.title = 'title'
-      assert_equal [], post.changed
+      # post.title = 'title'
+      # assert_equal [], post.changed
     end
 
     describe 'sti model' do
@@ -98,6 +98,18 @@ class DirtyTrackingTest < MiniTest::Spec
       post.title = nil
       assert_equal({ 'title' => ['title', nil] }, post.changes)
       post.save
+    end
+
+    it 'works for assigning new value == old value of other locale' do
+      post = Post.create(:title => nil, :content => 'content')
+      # assert_equal [], post.changed
+
+      post.title = 'english title'
+      assert_equal ['content', 'title'], post.changed
+
+      I18n.locale = :de
+      post.title  = nil
+      assert_equal ['content', 'title'], post.changed
     end
   end
 end


### PR DESCRIPTION
this solves the problem that the value can be set for a *different
locale* so it does not really re-set the value for the original locale
(#372)

a real solution would keep track of the old values *per locale*