### PR TITLE
remove usage of Thread.current for fallbacks

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -52,11 +52,11 @@ module Globalize
   protected
 
     def read_locale
-      Thread.current[:globalize_locale]
+      @globalize_locale
     end
 
     def set_locale(locale)
-      Thread.current[:globalize_locale] = locale.try(:to_sym)
+      @globalize_locale = locale.try(:to_sym)
     end
 
     def read_fallbacks


### PR DESCRIPTION
Fixes #362. Usage of the `Thread.current` hash causes fallback lookups to fail in some instances (see my [example app](https://github.com/hube/globalize-fallbacks)). This file has two other usages of `Thread.local` that may need to be reviewed but I chose not to remove them in order to make the minimum change necessary to address this issue.
