### PR TITLE
Added uniq to with_translations prevent duplications of records

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -9,7 +9,7 @@ module Globalize
 
       def with_translations(*locales)
         locales = translated_locales if locales.empty?
-        preload(:translations).joins(:translations).readonly(false).with_locales(locales)
+        preload(:translations).joins(:translations).readonly(false).with_locales(locales).references(:translations).uniq
       end
 
       def with_required_attributes


### PR DESCRIPTION
I am glad this part got some attention, however there is another issue now. Before I was patching `globalize` like this:

``` ruby
module Globalize::ActiveRecord::ClassMethods
  def with_translations(*locales)
    if locales.empty?
      includes(:translations).references(:translations) # my code
    else
      preload(:translations) # original code in the previous version
        .joins(:translations)
        .readonly(false)
        .with_locales(locales)
        .with_required_attributes
    end
  end
end
```

However the new way causes duplicated records to appear when using `model.with_translations`, I propose to add `uniq` at least. In fact it was perfect with: 

``` ruby
includes(:translations).references(:translations)
```

but in the current version adding `references(:translations)` is not enough it seems.
