### PR TITLE
Fixed correct table name for "news translations"

### DIFF
--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define do
     t.string :title
   end
 
-  create_table :news_item_translations, :force => true do |t|
+  create_table :news_translations, :force => true do |t|
     t.integer  'news_id'
     t.string     :locale
     t.string     :title


### PR DESCRIPTION
This fixes the error that occurs for test "create a translation class for model with custom table name".