### PR TITLE
Initialize Globalize just from model metadata.

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require 'patches/active_record/xml_attribute_serializer'
 require 'patches/active_record/query_method'
+require 'patches/active_record/serialization'
 require 'patches/active_record/uniqueness_validator'
 require 'patches/active_record/persistence'
 

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -63,10 +63,7 @@ module Globalize
       end
 
       def serializer_for_attribute(attr_name)
-        column = self.columns_hash[attr_name.to_s]
-        if column && column.cast_type.is_a?(::ActiveRecord::Type::Serialized)
-          column.cast_type.coder
-        end
+        @_serialized_attributes[attr_name] if @_serialized_attributes
       end
 
       def setup_translates!(options)

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,0 +1,58 @@
+module ActiveRecord
+  module AttributeMethods
+    module Serialization
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # If you have an attribute that needs to be saved to the database as an
+        # object, and retrieved as the same object, then specify the name of that
+        # attribute using this method and it will be handled automatically. The
+        # serialization is done through YAML. If +class_name+ is specified, the
+        # serialized object must be of that class on assignment and retrieval.
+        # Otherwise <tt>SerializationTypeMismatch</tt> will be raised.
+        #
+        # ==== Parameters
+        #
+        # * +attr_name+ - The field name that should be serialized.
+        # * +class_name_or_coder+ - Optional, a coder object, which responds to `.load` / `.dump`
+        #   or a class name that the object type should be equal to.
+        #
+        # ==== Example
+        #
+        #   # Serialize a preferences attribute.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences
+        #   end
+        #
+        #   # Serialize preferences using JSON as coder.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences, JSON
+        #   end
+        #
+        #   # Serialize preferences as Hash using YAML coder.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences, Hash
+        #   end
+        def serialize(attr_name, class_name_or_coder = Object)
+          # When ::JSON is used, force it to go through the Active Support JSON encoder
+          # to ensure special objects (e.g. Active Record models) are dumped correctly
+          # using the #as_json hook.
+          coder = if class_name_or_coder == ::JSON
+                    Coders::JSON
+                  elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
+                    class_name_or_coder
+                  else
+                    Coders::YAMLColumn.new(class_name_or_coder)
+                  end
+
+          @_serialized_attributes ||= {}
+          @_serialized_attributes[attr_name]= coder
+
+          decorate_attribute_type(attr_name, :serialize) do |type|
+            Type::Serialized.new(type, coder)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/data/models/without_table.rb
+++ b/test/data/models/without_table.rb
@@ -1,0 +1,8 @@
+# Don't remove this model.
+# Globalize model should be able to load when table is not present.
+# This is needed for example in migrations.
+
+class WithoutTable < ActiveRecord::Base
+  serialize :meta
+  translates :meta
+end


### PR DESCRIPTION
In refinery we found a serious bug.

When you try to run clean migrations, the DB table is not present yet. But `serializer_for_attribute` is using methods that needs table meta data and that cause crash you can see on [RefineryCMS CI](https://travis-ci.org/refinery/refinerycms/jobs/49285383). This was introduced in https://github.com/globalize/globalize/pull/402.

Since `serialized_attributes` are deprecated, we need to use similar approach that don't need actual table but can use model metadata. This is really naive and bad implementation, but it works.

Alternatively, we can revert #402 and get some time until Rails 5 lands (a lot of time now).

@parndt @shioyama 