### PR TITLE
`#cache_key` should change when translation changes

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -47,7 +47,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], :touch => true
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
           klass
         end
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -161,6 +161,10 @@ module Globalize
         globalize.send(:column_for_attribute, name)
       end
 
+      def cache_key
+        [super, translation.cache_key].join("/")
+      end
+
     protected
 
       def each_locale_and_translated_attribute

--- a/test/data/models/product.rb
+++ b/test/data/models/product.rb
@@ -1,0 +1,3 @@
+class Product < ActiveRecord::Base
+  translates :name
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -41,6 +41,17 @@ ActiveRecord::Schema.define do
     t.datetime   :published_at
   end
 
+  create_table :products, :force => true do |t|
+    t.timestamps :null => false
+  end
+
+  create_table :product_translations, :force => true do |t|
+    t.string     :locale
+    t.references :product
+    t.string     :name
+    t.timestamps :null => false
+  end
+
   create_table :parents, :force => true do |t|
   end
 

--- a/test/globalize/cache_key_test.rb
+++ b/test/globalize/cache_key_test.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require File.expand_path('../../test_helper', __FILE__)
+
+class CacheKeyTest < MiniTest::Spec
+
+  describe '#cache_key' do
+    it "changes when the translation is updated" do
+      product = with_locale(:en) { Product.create(:name => 'first') }
+      original_cache_key = product.cache_key
+
+      product_translation = product.translation_for(:en)
+      product_translation.name = "second"
+      product_translation.save!
+
+      refute_equal original_cache_key, product.cache_key
+    end
+  end
+end

--- a/test/globalize/cache_key_test.rb
+++ b/test/globalize/cache_key_test.rb
@@ -15,5 +15,11 @@ class CacheKeyTest < MiniTest::Spec
 
       refute_equal original_cache_key, product.cache_key
     end
+
+    it "works even for an uninitialized locale" do
+      product = with_locale(:en) { Product.create(:name => 'first') }
+
+      refute_nil with_locale(:de) { product.cache_key }
+    end
   end
 end


### PR DESCRIPTION
Following up from #330, this is an alternate solution. Rather than forcing the 'parent' model object to be updated if the translation changes, we modify the implementation of `#cache_key` for translated models so that it incorporates the cache_key of the translation as well.

This results in a cache key of:

`products/1-20150206003237457906000/product/translations/new`

for a new translation

and 

`products/1-20150206000856438942000/product/translations/1-20150206000856442618000`

for an existing translation

I'd welcome comments and feedback, in particular if @shlensky could try this out to see if it works in his codebase.