### PR TITLE
Make Globalize thread safe by default again.

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -5,7 +5,6 @@ require 'patches/active_record/serialization'
 require 'patches/active_record/uniqueness_validator'
 require 'patches/active_record/persistence'
 
-
 module Globalize
   autoload :ActiveRecord, 'globalize/active_record'
   autoload :Interpolation,   'globalize/interpolation'
@@ -52,18 +51,22 @@ module Globalize
       i18n_fallbacks? ? I18n.fallbacks[for_locale] : [for_locale.to_sym]
     end
 
+    def storage
+      Thread.current
+    end
+
   protected
 
     def read_locale
-      @globalize_locale
+      storage[:globalize_locale]
     end
 
     def set_locale(locale)
-      @globalize_locale = locale.try(:to_sym)
+      storage[:globalize_locale] = locale.try(:to_sym)
     end
 
     def read_fallbacks
-      @fallbacks || HashWithIndifferentAccess.new
+      storage[:globalize_fallbacks] || HashWithIndifferentAccess.new
     end
 
     def set_fallbacks(locales)
@@ -73,7 +76,7 @@ module Globalize
         fallback_hash[key] = value.presence || [key]
       end if locales.present?
 
-      @fallbacks = fallback_hash
+      storage[:globalize_fallbacks] = fallback_hash
     end
   end
 end

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -217,4 +217,28 @@ class GlobalizeTest < MiniTest::Spec
       end
     end
   end
+
+  describe 'with locale' do
+    def perform_with_locale(locale)
+      Thread.new do
+        Globalize.with_locale(locale) do
+          sleep 1
+          assert_equal locale, Globalize.locale
+        end
+      end
+    end
+
+    it 'succeed in one thread' do
+      thread = perform_with_locale(:end)
+      thread.join
+    end
+
+    it 'succeed multithreading' do
+      thread1 = perform_with_locale(:en)
+      thread2 = perform_with_locale(:fr)
+      thread3 = perform_with_locale(:de)
+
+      thread1.join && thread2.join && thread3.join
+    end
+  end
 end


### PR DESCRIPTION
I think it is easy enough to use custom storage just by overriding storage method on Globalize. I was thinking about getter and setter for that, but proc will be needed there probably and it looks ugly in config.

https://github.com/globalize/globalize/commit/37c19b5f8b19ba14bc89f7237064857d46ad815d :red_circle: fails without https://github.com/globalize/globalize/commit/b1857194a147ef2a0d3bd99d3c7cab17d0683edc :green_heart: 

related to #390 #374 

ping @mtparet @hube @parndt @Dschee