### PR TITLE
Add request_store to make Globalize thread safe with threaded web servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.0 (unreleased)
 
 * Replaced `after_` callbacks with `before_` callbacks and set `autosave: true` by default. [#341](https://github.com/globalize/globalize/pull/341) by [Andrew Volozhanin](https://github.com/scarfacedeb)
+* Add [RequestStore](https://github.com/steveklabnik/request_store) to make Globalize thread-safe again [#420](https://github.com/globalize/globalize/pull/420)
 
 ## 5.0.1 (2015-02-15)
 

--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 4.2.0', '< 4.3'
   s.add_dependency 'activemodel', '>= 4.2.0', '< 4.3'
+  s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'database_cleaner', '~> 1.4.0'
   s.add_development_dependency 'minitest'

--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -1,10 +1,10 @@
+require 'request_store'
 require 'active_record'
 require 'patches/active_record/xml_attribute_serializer'
 require 'patches/active_record/query_method'
 require 'patches/active_record/serialization'
 require 'patches/active_record/uniqueness_validator'
 require 'patches/active_record/persistence'
-
 
 module Globalize
   autoload :ActiveRecord, 'globalize/active_record'
@@ -52,18 +52,23 @@ module Globalize
       i18n_fallbacks? ? I18n.fallbacks[for_locale] : [for_locale.to_sym]
     end
 
+    # Thread-safe global storage
+    def storage
+      RequestStore.store
+    end
+
   protected
 
     def read_locale
-      @globalize_locale
+      storage[:globalize_locale]
     end
 
     def set_locale(locale)
-      @globalize_locale = locale.try(:to_sym)
+      storage[:globalize_locale] = locale.try(:to_sym)
     end
 
     def read_fallbacks
-      @fallbacks || HashWithIndifferentAccess.new
+      storage[:globalize_fallbacks] || HashWithIndifferentAccess.new
     end
 
     def set_fallbacks(locales)
@@ -73,7 +78,7 @@ module Globalize
         fallback_hash[key] = value.presence || [key]
       end if locales.present?
 
-      @fallbacks = fallback_hash
+      storage[:globalize_fallbacks] = fallback_hash
     end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -327,6 +327,13 @@ def cache_key
 end
 ```
 
+## Thread-safety
+
+Globalize uses [request_store](https://github.com/steveklabnik/request_store) gem to clean up thread-global variable after every request.
+RequestStore includes a Railtie that will configure everything properly for Rails 3+ apps.
+
+If you're not using Rails, you may need to consult a RequestStore's [README](https://github.com/steveklabnik/request_store#no-rails-no-problem) to configure it.
+
 ## Tutorials and articles
 * [Go Global with Rails and I18n](http://www.sitepoint.com/go-global-rails-i18n/) - introductory article about i18n in Rails (Ilya Bodrov)
 

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -217,4 +217,30 @@ class GlobalizeTest < MiniTest::Spec
       end
     end
   end
+
+  describe '#with_locale' do
+    def perform_with_locale(locale)
+      Thread.new do
+        Globalize.with_locale(locale) do
+          Thread.pass
+          assert_equal locale, Globalize.locale
+        end
+      end
+    end
+
+    it 'sets locale in a single thread' do
+      perform_with_locale(:end).join
+    end
+
+    it 'sets independent locales in multiple threads' do
+      threads = []
+      threads << perform_with_locale(:en)
+      threads << perform_with_locale(:fr)
+      threads << perform_with_locale(:de)
+      threads << perform_with_locale(:cz)
+      threads << perform_with_locale(:pl)
+
+      threads.each(&:join)
+    end
+  end
 end


### PR DESCRIPTION
It adds `request_store` gem to resolve #224 issue and make Globalize thread-safe by default.
Code is basically a modification of @simi work in #413.

I added more threads to the multithreading test, because I noticed that test would randomly succeed with ivars, instead of `Thread.current` or `RequstStore.store` 1 out of 6 times.
Increasing number of threads to 5 resolved that issue and now I always get failure with ivars.

Unfortunately, I couldn't come up with a way to test #224 issue.
In theory, I could create a test that would reuse threads (in a similar way as puma and thin servers do it), but I think it would be too superfluous and fake.
The better test would be to run those servers and assert that `Globalize.locale` value is unset after every request, but it also seems too unnecessary, because it seems to me that we would be testing an external gem, instead of globalize code.

@simi @parndt what do you think?