### PR TITLE
Refactor translation_class to lookup constant only in the receiver

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -42,8 +42,9 @@ module Globalize
 
       def translation_class
         @translation_class ||= begin
-          klass = self.const_get(:Translation) rescue nil
-          if klass.nil? || klass.class_name != (self.class_name + "Translation")
+          if self.const_defined?(:Translation, false)
+            klass = self.const_get(:Translation, false)
+          else
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 


### PR DESCRIPTION
The second parameter in `const_defined?` and `const_get` determines if it should lookup in the ancestors.
It prevents `const_get` from getting `::Translation` model, instead of `klass::Translation`.
I think that it makes this code a bit cleaner.

Related commit: https://github.com/globalize/globalize/commit/e0d1f57153ab97516665cb48f65f982c70d21433