### PR TITLE
Derive foreign_key from Rails

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -13,13 +13,6 @@ module Globalize
         allow_translation_of_attributes(attr_names) if attr_names.present?
       end
 
-      def class_name
-        @class_name ||= begin
-          class_name = table_name[table_name_prefix.length..-(table_name_suffix.length + 1)].downcase.camelize
-          pluralize_table_names ? class_name.singularize : class_name
-        end
-      end
-
       def translates?
         included_modules.include?(InstanceMethods)
       end
@@ -42,7 +35,6 @@ module Globalize
 
       def apply_globalize_options(options)
         options[:table_name] ||= "#{table_name.singularize}_translations"
-        options[:foreign_key] ||= class_name.foreign_key
 
         class_attribute :translated_attribute_names, :translation_options, :fallbacks_for_empty_translations
         self.translated_attribute_names = []

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -68,8 +68,19 @@ module Globalize
                                 :extend      => HasManyExtensions,
                                 :autosave    => true
 
+        save_foreign_key
+        setup_translation_model
+
         before_create :save_translations!
         before_update :save_translations!
+      end
+
+      def save_foreign_key
+        self.translation_options[:foreign_key] = reflect_on_association(:translations).foreign_key
+      end
+
+      def setup_translation_model
+        translation_class.belongs_to :globalized_model, class_name: self.name, foreign_key: translation_options[:foreign_key]
       end
     end
 

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -43,13 +43,10 @@ module Globalize
       def translation_class
         @translation_class ||= begin
           if self.const_defined?(:Translation, false)
-            klass = self.const_get(:Translation, false)
+            self.const_get(:Translation, false)
           else
-            klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
+            self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
-
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
-          klass
         end
       end
 

--- a/test/data/models/media.rb
+++ b/test/data/models/media.rb
@@ -1,3 +1,4 @@
 class Media < ActiveRecord::Base
   self.table_name = "medias"
+  translates :title
 end

--- a/test/data/models/picture.rb
+++ b/test/data/models/picture.rb
@@ -1,5 +1,4 @@
 require File.expand_path('../media', __FILE__)
 
 class Picture < Media
-  translates :title
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -64,11 +64,12 @@ ActiveRecord::Schema.define do
 
   create_table :comments, :force => true do |t|
     t.references :post
+    t.string :type
   end
 
   create_table :comment_translations, :force => true do |t|
     t.string     :locale
-    t.references :comment
+    t.references :translated_comment
     t.string     :title
     t.text       :content
   end
@@ -210,6 +211,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :medias, :force => true do |t|
+    t.string :type
   end
 
   create_table :media_translations, :force => true do |t|

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -215,7 +215,7 @@ protected
   end
 
   def assert_migration_table(fields, model = Migrated)
-    index_field = :"#{model.class_name.underscore}_id"
+    index_field = :"#{model.model_name.singular.underscore}_id"
     assert model.translation_class.table_exists?
     assert model.translation_class.index_exists_on?(index_field)
 


### PR DESCRIPTION
`class_name` method is used to derive `foreign_key` for associations from table names.

I think it's a good idea to remove it and allow rails itself to derive foreign_key value. (in cases when it's not defined by hand)

The problem with `class_name` is that its output diverges from the rails, because class_name uses table_name, instead of variation of model_name.

I removed `class_name`, but it broke tests that involve STI.
First of all, I added missing `type` columns to adhere to the latest rails conventions.

After that, I decided to refactor those models to illustrate 2 cases:
- When translates is called on parent STI model: `Media` and `Picture` models. 
- When translates is called on inherited STI model and foreign key is derived from that model: `Comment` and `TranslatedComment` models.

These changes required to rename foreign_key for `TranslatedComment` model from `comment_id` to `translated_comment_id`.

I think that it makes more sense, because we're only associating TranslatedComment records with translations,  not all of the comments. 
Also Rails is expecting this foreign key by default.

All of it unfortunately leads to backward incompatibility in cases when `transaltes` macro is called from inherited STI models.
