### PR TITLE
Add UUID support

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -67,8 +67,8 @@ module Globalize
         end
 
         def create_translation_table
-          connection.create_table(translations_table_name) do |t|
-            t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false
+          connection.create_table(translations_table_name, id: primary_key_type) do |t|
+            t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, null: false, type: primary_key_type
             t.string :locale, :null => false
             t.timestamps :null => false
           end
@@ -140,6 +140,10 @@ module Globalize
             type = (options.is_a? Hash) ? options[:type] : options
             raise BadFieldType.new(name, type) unless valid_field_type?(name, type)
           end
+        end
+
+        def primary_key_type
+          column_type(model.primary_key).to_sym
         end
 
         def column_type(name)


### PR DESCRIPTION
When the model that needs to be translated uses UUID as primary key, this pr will make the translation model also UUID. Setting the reference type is supported since 4.2 but if i'm correct the depency listen in the gemspec specifies 4.2

It's not perfect, but works.

Any ideas?
