### PR TITLE
Unsaved records does not have any translations

### DIFF
--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -108,6 +108,7 @@ class AttributesTest < MiniTest::Spec
 
       post.title = 'something'
       assert post.translations.all?(&:new_record?)
+      assert_equal 1, post.translations.length
 
       post.save
       assert post.translations.all?(&:persisted?)


### PR DESCRIPTION
While a model is unsaved the translations method returns an empty array.
The attribute_translations returns the proper translations though.
