### PR TITLE
To make uniqueness validator work with squeel (Rails 3.0)

### DIFF
--- a/lib/patches/active_record/uniqueness_validator.rb
+++ b/lib/patches/active_record/uniqueness_validator.rb
@@ -31,7 +31,7 @@ ActiveRecord::Validations::UniquenessValidator.class_eval do
 
         sql, params  = mount_sql_and_params(finder_class, table_name, attribute, value)
 
-        relation = table.where(sql, *params).where(:locale => Globalize.locale)
+        relation = table.where(sql, *params).where(:locale => Globalize.locale.to_s)
 
         Array.wrap(options[:scope]).each do |scope_item|
           scope_value = record.send(scope_item)


### PR DESCRIPTION
Please consider this to be fixed although 3-0-stable might be already out of support, but without this change, it causes ActiveRecord::StatementInvalid exception if the application uses squeel gem and the translated model uses the uniqueness validation.

https://github.com/activerecord-hackery/squeel#symbols-as-the-value-side-of-a-condition-in-normal-where-clauses
"If you have any where() clauses that use a symbol as the value side (right-hand side) of a condition, you will need to change the symbol into a string in order for it to continue to be treated as a value."