### PR TITLE
Ensure order for translations

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -71,7 +71,8 @@ module Globalize
 
         translation_class.table_name = options[:table_name]
 
-        has_many :translations, :class_name  => translation_class.name,
+        has_many :translations, -> { order(:created_at => :desc) },
+                                :class_name  => translation_class.name,
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,


### PR DESCRIPTION
As some DB Engines do not ensure the order of the returned rows, it could happen that translations are not ordered correctly. So we have to ensure the correct sorting on the has_many association.
