### PR TITLE
New branch to work on non char-based table column type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ gem 'globalize', '~> 3.1.0'
 
 The [`3-1-stable` branch](https://github.com/globalize/globalize/tree/3-1-stable) of this repository corresponds to the latest ActiveRecord 3 version of globalize. Note that `globalize3` has been deprecated and you are encouraged to update your Gemfile accordingly.
 
+If you need support for **non char-based column types** (e.g. numeric and date types) you might want to include the feature branch `non_charbased_type_support` (wich is a work in progress) like so:
+
+``` ruby
+gem 'globalize', github: "globalize/globalize', branch: 'feature/non_charbased_type_support'
+```
+
 ## Model translations
 
 Model translations allow you to translate your models' attribute values. E.g.
@@ -175,6 +181,8 @@ translates :title, :author
 Because globalize uses the `:locale` key to specify the locale during
 mass-assignment, you should avoid having a `locale` attribute on the parent
 model.
+
+Also globalize currently only supports **char-based column types** (:string and :text). If you need support for other types you can refer to the feature branch named `non_charbased_type_support` with some work in progress for that.
 
 ## Versioning with Globalize
 

--- a/lib/globalize/active_record/exceptions.rb
+++ b/lib/globalize/active_record/exceptions.rb
@@ -11,7 +11,7 @@ module Globalize
 
       class BadFieldType < MigrationError
         def initialize(name, type)
-          super("Bad field type for field #{name.inspect} (#{type.inspect}), should be :string or :text")
+          super("Bad field type for field #{name.inspect} (#{type.inspect}), should be :string, :text, :integer, :float, :decimal, :datetime, :time, :date or :boolean")
         end
       end
     end

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -151,7 +151,8 @@ module Globalize
         end
 
         def valid_field_type?(name, type)
-          !translated_attribute_names.include?(name) || [:string, :text].include?(type)
+          valid_types = [:string, :text, :integer, :float, :decimal, :datetime, :time, :date, :boolean]
+          !translated_attribute_names.include?(name) || valid_types.include?(type)
         end
 
         def translation_index_name

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -45,7 +45,7 @@ class MigrationTest < MiniTest::Spec
 
     it 'raises BadFieldName if passed translated field with wrong type' do
       assert_raises BadFieldType do
-        Migrated.create_translation_table!(:name => :integer)
+        Migrated.create_translation_table!(:name => :binary)
       end
     end
 


### PR DESCRIPTION
This request is only to get work started in order to support more data types than just `string` and `text`. The only thing I changed here is to remove the restriction to the two types and add some reference to this work within the README file. Referring to multiple users in the #187 issue the changes here should already work for most cases.

Of course this doesn't mean there's now full support for more types, but this should get us started and give people the option to try this branch out and see what the edge cases are so we can cover them. Here's some next steps to do:
- [ ] Write test code for each specific added type (integer, float, decimal, datetime, time, date, boolean)
- [ ] Figure out if `primary_key` and `binary` types should or could be enabled and enable them, if needed
- [ ] Update Documentation in README file to include numeric/date/boolean examples

I'm looking forward to your opinions. Thanks to @vizo for pointing towards the code to change.
