### PR TITLE
Inform about required translates call in the model before creating translations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ and `drop_translation_table!` inside the `change` instance method.
 
 ***Do not use the `change` method, use `up` and `down`!***
 
+Also note that before you can create a translation table, you have to define the translated attributes via `translates` in your model as shown above.
+
 ```ruby
 class CreatePosts < ActiveRecord::Migration
   def up


### PR DESCRIPTION
Without the translates call I got `undefined method `create_translation_table!' for #<Class:0x00000009124130>/` and when just specifying one of them I got `Missing translated field :banner_headline` - had to add them all for it to work. Information would be nice to have in the README so others don't make the same mistake as I did.

Thank you very much for your work :+1: