### PR TITLE
Improve performances of translated_attributes of instance_methods

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -93,9 +93,11 @@ module Globalize
       end
 
       def translated_attributes
-        translated_attribute_names.inject({}) do |attributes, name|
-          attributes.merge(name.to_s => translation.send(name))
+        attrs = {}
+        translated_attribute_names.each do |name|
+          attrs[name.to_s] = translation.send(name)
         end
+        attrs
       end
 
       # This method is basically the method built into Rails


### PR DESCRIPTION
While profiling one of my project I saw one line of globalize accounted for half of one my projects allocations. A merge was used in an inject loop, leading to the allocations of numerous useless hashes. I simply used the formalism in the method below and performances greatly improved.
