### PR TITLE
Add config option to globally enable fallbacks for empty translations

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -51,6 +51,15 @@ module Globalize
     def default_fallbacks(for_locale = self.locale)
       i18n_fallbacks? ? I18n.fallbacks[for_locale] : [for_locale.to_sym]
     end
+    
+    def fallbacks_for_empty_translations=(value = false)
+      return if !!value != value # Only allow booleans
+      storage[:globalize_fallback_empty_translations] = value
+    end
+
+    def fallbacks_for_empty_translations?
+      !!storage[:globalize_fallback_empty_translations]
+    end
 
     # Thread-safe global storage
     def storage

--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -53,7 +53,7 @@ module Globalize
     end
     
     def fallbacks_for_empty_translations=(value = false)
-      return if !!value != value # Only allow booleans
+      return if [true, false].include? value
       storage[:globalize_fallback_empty_translations] = value
     end
 

--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -83,7 +83,7 @@ module Globalize
       end
 
       def fallbacks_for?(object)
-        object.nil? || (fallbacks_for_empty_translations? && object.blank?)
+        object.nil? || (Globalize.fallbacks_for_empty_translations? && object.blank?) || (fallbacks_for_empty_translations? && object.blank?)
       end
 
       delegate :fallbacks_for_empty_translations?, :to => :record, :prefix => false

--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -83,7 +83,7 @@ module Globalize
       end
 
       def fallbacks_for?(object)
-        object.nil? || (Globalize.fallbacks_for_empty_translations? && object.blank?) || (fallbacks_for_empty_translations? && object.blank?)
+        object.blank? && (Globalize.fallbacks_for_empty_translations? || fallbacks_for_empty_translations?)
       end
 
       delegate :fallbacks_for_empty_translations?, :to => :record, :prefix => false

--- a/test/globalize/fallbacks_test.rb
+++ b/test/globalize/fallbacks_test.rb
@@ -93,6 +93,20 @@ class FallbacksTest < MiniTest::Spec
       assert_equal 'foo', post.title
     end
 
+    it 'resolves fallbacks with empty translations' do
+      Globalize.fallbacks_for_empty_translations = true
+      I18n.fallbacks.map :'de-DE' => [ :'en-US' ]
+      post = Post.create :title => 'foo'
+
+      I18n.locale = :'de-DE'
+      assert_equal 'foo', post.title
+
+      post.update_attributes :title => ""
+      assert_equal 'foo', post.title
+
+      Globalize.fallbacks_for_empty_translations = false
+    end
+
     it 'supports fallbacks to each other' do
       I18n.fallbacks.clear
       Globalize.fallbacks = {:en => [:en, :pl], :pl => [:pl, :en]}


### PR DESCRIPTION
I don't know if this is an edge case or not, but I added the option to enable fallbacks for empty translations for all models. It might not be necessary, but I thought it might be useful in some cases.
