### PR TITLE
Clear schema cache before adding missing columns

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -175,6 +175,7 @@ module Globalize
         private
 
         def add_missing_columns
+          clear_schema_cache!
           translated_attribute_names.map(&:to_s).each do |attribute|
             unless model.column_names.include?(attribute)
               connection.add_column(table_name, attribute, model::Translation.columns_hash[attribute].type)


### PR DESCRIPTION
To make sure that the columns are really missing.