### PR TITLE
validate uniqueness of translated attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ Gemfile.lock
 *.gem
 .rbx
 .ruby-version
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 *.gem
 .rbx
 .ruby-version
+.idea/

--- a/test/globalize/dup_test.rb
+++ b/test/globalize/dup_test.rb
@@ -32,14 +32,13 @@ class DupTest < MiniTest::Spec
       dupd = original.dup.tap do |new_model|
         new_model.title = "Foo New Model"
       end
-      original.translations.each do |translation|
-        dupd.translations << translation.dup
-      end
+
       dupd.save!
 
       original.reload
       assert_equal "Foo New Model", dupd.title
       assert_equal original_title, original.title
+      assert_equal "שם", dupd.translations.find_by!(locale: 'he').title
     end
 
   end

--- a/test/globalize/validations_test.rb
+++ b/test/globalize/validations_test.rb
@@ -145,6 +145,34 @@ class ValidationsTest < MiniTest::Spec
     end
   end
 
+  describe ',duplicated translations' do
+    let(:post) { Post.create(title: 'foo') }
+
+
+    describe 'create new :en translation for same post' do
+      it 'should raise an error' do
+        assert_raises ActiveRecord::RecordInvalid do
+          post.translations.create!(locale: :en, title: 'bar' )
+        end
+      end
+    end
+
+    describe 'create new :de translation for same post' do
+      before do
+        post.translations.create!(locale: :de, title: 'bar' )
+      end
+
+      describe 'and change locale to :en' do
+        it 'should raise an error' do
+          assert_raises ActiveRecord::RecordInvalid do
+            post.translations.find_by(locale: :de).update_attributes!(locale: :en)
+          end
+        end
+      end
+    end
+
+  end
+
   # describe ".validates_associated" do
   # end
 end


### PR DESCRIPTION
It is possible to create duplicated translations, which should in my opinion not be possible.

E.g.
`5.times { |i| some_obj.translations.create!(locale: :en, title: "title ##{i}") }`
is possible, which will lead to 5 english translations for the same record.
