### PR TITLE
Added uniq to with_translations to prevent duplicates when fallbacks are defined

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -13,7 +13,7 @@ module Globalize
 
       def with_translations(*locales)
         locales = translated_locales if locales.empty?
-        preload(:translations).joins(:translations).readonly(false).with_locales(locales)
+        preload(:translations).joins(:translations).readonly(false).with_locales(locales).uniq
       end
 
       def with_required_attributes

--- a/test/globalize/fallbacks_test.rb
+++ b/test/globalize/fallbacks_test.rb
@@ -215,6 +215,27 @@ class FallbacksTest < MiniTest::Spec
       assert_equal translations, user.name_translations
     end
   end
+  
+  describe 'query with fallbacks' do
+    it 'does not result in duplicated records' do
+      I18n.fallbacks.clear
+      I18n.fallbacks.map :en => [ :de, :fr ]
+      I18n.locale = :en
+      
+      product = Product.create(:name => 'foooooooo')
+      with_locale(:de) { product.name = 'bar' }
+      product.save!
+      
+      assert_equal 1, Product.with_translations.where(id: product.id).length
+      assert_equal 'foooooooo', Product.find(product.id).name
+      
+      I18n.locale = :de
+      assert_equal 'bar', Product.find(product.id).name
+      
+      I18n.locale = :fr
+      assert_equal 'foooooooo', Product.find(product.id).name
+    end
+  end
 end
 # TODO should validate_presence_of take fallbacks into account? maybe we need
 #   an extra validation call, or more options for validate_presence_of.


### PR DESCRIPTION
I also added a test case which fails if the `uniq` in `with_translations` is removed.

Without this fix duplicate records appear if fallbacks are defined and the locale is not the default/fallback locale.