### PR TITLE
Use I18n.locale instead of default_locale when migrating data

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ end
 
 NOTE: Make sure you drop the translated columns from the parent table after all your data is safely migrated.
 
+In order to use a specific locale for migrated data, you can use `I18n.with_locale`:
+
+```ruby
+    I18n.with_locale(:bo) do
+      Post.create_translation_table!({
+        :title => :string,
+        :text => :text
+      }, {
+        :migrate_data => true
+      })
+    end
+```
+
 ## Adding additional fields to the translation table
 
 In order to add a new field to an existing translation table, you can use `add_translation_fields!`:

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -114,7 +114,7 @@ module Globalize
 
         def move_data_to_translation_table
           model.find_each do |record|
-            translation = record.translation_for(I18n.default_locale) || record.translations.build(:locale => I18n.default_locale)
+            translation = record.translation_for(I18n.locale) || record.translations.build(:locale => I18n.locale)
             fields.each do |attribute_name, attribute_type|
               translation[attribute_name] = record.read_attribute(attribute_name, {:translated => false})
             end


### PR DESCRIPTION
It would allow to choose the locale used in migration like this:

```ruby
I18n.with_locale(:bo) do
  Product.create_translation_table!({ name: :string, values: { type: :string, array: true }, hint: :text }, migrate_data: true)
end
```