### PR TITLE
Add support default values 

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -68,7 +68,13 @@ module Globalize
 
       def fetch_attribute(locale, name)
         translation = record.translation_for(locale, false)
-        return translation && translation.send(name)
+        return translation ? translation.send(name) : default_value(name)
+      end
+
+      def default_value(name)
+        column = column_for_attribute(name)
+
+        column.type_cast_from_database(column.default)
       end
 
       def set_metadata(object, metadata)

--- a/test/data/models/product.rb
+++ b/test/data/models/product.rb
@@ -1,3 +1,3 @@
 class Product < ActiveRecord::Base
-  translates :name
+  translates :name, :array_values
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define do
     t.string     :locale
     t.references :product
     t.string     :name
+    t.string     :array_values, :array => true, :null => false, :default => []
     t.timestamps :null => false
   end
 

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -213,6 +213,14 @@ class AttributesTest < MiniTest::Spec
     end
   end
 
+  describe 'columns with default array value' do
+    it 'returns the typecasted default value for arrays with empty array as default' do
+      product = Product.new
+
+      assert_equal "--- []\n", product.array_values
+    end
+  end
+
   describe 'translation table with null:false fields without default value ' do
     it 'does not save a record with an empty required field' do
       err = assert_raises ActiveRecord::StatementInvalid do

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -106,7 +106,6 @@ class MigrationTest < MiniTest::Spec
       # Was it restored? (also tests .untranslated_attributes)
       assert_equal 'Untranslated', untranslated.untranslated_attributes['name']
     end
-
   end
 
   describe 'add_translation_fields!' do


### PR DESCRIPTION
When default value is specified for a given column in a migration, when there is no pre-existing translation on a record, trying to get the attribute will return nil instead of the default value.

The migration:

```ruby
Product.create_translation_table!(values: { type: :string, array: true, null: false, default: [] })
```

Currently, we get:

```ruby
Product.new.values
=> nil
```

I would rather expect:

```ruby
Product.new.values
=> []
```

With this PR, I get:

```ruby
Product.new.values
=> "{}"
```

This is better but needs a conversion, I did not figure how to do it yet.
