### PR TITLE
Enhance association to translations

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -72,6 +72,7 @@ module Globalize
 
         has_many :translations, :class_name  => translation_class.name,
                                 :foreign_key => options[:foreign_key],
+                                :inverse_of  => translation_class.globalized_association,
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
                                 :autosave    => true

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -50,9 +50,10 @@ module Globalize
             klass = self.const_get(:Translation, false)
           else
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
+            klass.globalized_class = self
+            klass.belongs_to klass.globalized_association, :class_name => self.name, :foreign_key => translation_options[:foreign_key], :inverse_of => :translations
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
           klass
         end
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -102,7 +102,7 @@ module Globalize
           # Fetch translations from database as those in the translation collection may be incomplete
           _translation = translations.detect{|t| t.locale.to_s == locale.to_s}
           _translation ||= translations.with_locale(locale).first unless translations.loaded?
-          _translation ||= translations.build(:locale => locale) if build_if_missing
+          _translation ||= translations.build((globalize.stash.delete(locale) || {}).merge(locale: locale)) if build_if_missing
           translation_caches[locale] = _translation if _translation
         end
         translation_caches[locale]

--- a/lib/globalize/active_record/translation.rb
+++ b/lib/globalize/active_record/translation.rb
@@ -1,6 +1,8 @@
 module Globalize
   module ActiveRecord
     class Translation < ::ActiveRecord::Base
+      RESERVED_ASSOCIATION_NAMES = [:locale]
+      class_attribute :globalized_class
 
       validates :locale, :presence => true
 
@@ -21,6 +23,11 @@ module Globalize
 
         def translated_locales
           select('DISTINCT locale').order(:locale).map(&:locale)
+        end
+
+        def globalized_association
+          association = globalized_class.name.demodulize.underscore.to_sym
+          RESERVED_ASSOCIATION_NAMES.include?(association) ? :globalized_model : association
         end
       end
 

--- a/lib/patches/active_record/rails5/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails5/uniqueness_validator.rb
@@ -15,7 +15,7 @@ module Globalize
           translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
           untranslated_scopes = Array(options[:scope]) - translated_scopes
 
-          relation = relation.joins(:globalized_model) if untranslated_scopes.present?
+          relation = relation.joins(finder_class.globalized_association) if untranslated_scopes.present?
           untranslated_scopes.each do |scope_item|
             scope_value = record.send(scope_item)
             reflection = klass.reflect_on_association(scope_item)

--- a/test/globalize/translation_class_test.rb
+++ b/test/globalize/translation_class_test.rb
@@ -13,12 +13,12 @@ class TranslationClassTest < MiniTest::Spec
     end
 
     it 'defines a belongs_to association' do
-      assert_belongs_to Post::Translation, :globalized_model
+      assert_belongs_to Post::Translation, :post
     end
 
     it 'defines a belongs_to association for abstracted class' do
       picture = Picture.create!(:title => "content fr", :locale => "fr")
-      assert_equal picture.translations.first.globalized_model, picture
+      assert_equal picture.translations.first.picture, picture
     end
 
     it 'defines a reader for :locale that returns a symbol' do


### PR DESCRIPTION
- Use rails convention on translation_class.belongs_to.
  `Post::Translation` will belong to `:post`.
  `picture.translations.first.picture` will be a `Picture`.
- Use `inverse_of` on both sides to improve performance.
  This is also helpful when trying to validate presence of
  association when both sides are not persisted yet.
- `#globalized_association` can calculate association name.
  `Post::Translation` will use `:post` to belong to.
  Fall back to `:globalized_model` if association model is reserved.
  `Locale::Translation` will use `:globalized_model` to belong to.
- Fix bugs in `#set_translations`.
  `post = Post.new(title: "Title")` will save title in `globalize.stash`
  `post.set_translations(title: "Updated Title")` will create a translation
  but ignore values saved in `globalize.stash` and then invoke
  `globalize.save_translations!` which use values in `globalize.stash`
  to create another translation. The translation created by
  `set_translations(title: "Updated Title")` will not be saved.
  New implementation uses values from `globalize.stash` to create the
  translation and remove values from `globalize.stash`. Only one
  translation will be created and saved
