### PR TITLE
Tidy up of Rails version requirement for 5.0.0.rc1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ vendor
 NOTES
 .DS_Store
 .bundle
-Gemfile.lock
+Gemfile*.lock
 .rvmrc
 *.sw*
 *.gem

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,4 @@ end
 
 group :test do
   gem 'pry'
-  gem 'pry-nav'
 end

--- a/gemfiles/Gemfile.rails5
+++ b/gemfiles/Gemfile.rails5
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel', '5.0.0.beta3'
-gem 'activerecord', '5.0.0.beta3'
+gem 'activemodel', '>= 5.0.0.rc1'
+gem 'activerecord', '>= 5.0.0.rc1'
 gem 'activemodel-serializers-xml'
 
 platforms :rbx do
@@ -12,5 +12,4 @@ end
 
 group :test do
   gem 'pry'
-  gem 'pry-nav'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require 'logger'
 Bundler.require(:default, :test)
 
 log = '/tmp/globalize3_test.log'
-FileUtils.touch(log) unless File.exists?(log)
+FileUtils.touch(log) unless File.exist?(log)
 ActiveRecord::Base.logger = Logger.new(log)
 ActiveRecord::LogSubscriber.attach_to(:active_record)
 ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')


### PR DESCRIPTION
Also replaced deprecated File.exists? with File.exist?
Also removed pry-nav due to circular require problem.

The version specification is greedy, but the gemspec forces `< 5.1`