### PR TITLE
The DB variable is a lie, removing it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 sudo: false
 script: "bundle exec rake"
 gemfile:
- - Gemfile
- - gemfiles/Gemfile.rails5
+  - Gemfile
+  - gemfiles/Gemfile.rails5
 rvm:
   - 2.3.1
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ script: "bundle exec rake"
 gemfile:
  - Gemfile
  - gemfiles/Gemfile.rails5
-env:
-  - DB=sqlite3
-  - DB=postgres
-  - DB=mysql
 rvm:
   - 2.3.1
   - 2.2
@@ -17,9 +13,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx
-    - env: RAILS_4_2=true DB=sqlite3
-    - env: RAILS_4_2=true DB=postgres
-    - env: RAILS_4_2=true DB=mysql
   exclude:
     - rvm: 2.2
       gemfile: gemfiles/Gemfile.rails5


### PR DESCRIPTION
The tests only ever run under sqlite3 based on [this line in test_helper.rb](https://github.com/globalize/globalize/blob/6f073f9129985daa81dab9eff242f79f84d79d44/test/test_helper.rb#L12):

```ruby
ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
```