### PR TITLE
fix order by hash with string keys

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -94,7 +94,7 @@ module Globalize
       def parse_translated_order(opts)
         case opts
         when Hash
-          ordering = opts.map do |column, direction|
+          ordering = opts.symbolize_keys.map do |column, direction|
             klass = translated_column?(column) ? translation_class : self
             klass.arel_table[column].send(direction)
           end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -193,6 +193,11 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
             assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
           end
 
+          it 'returns record in order, column and direction as hash with string keys' do
+            @order = Post.where(:title => 'title').order('title' => :desc)
+            assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
+          end
+
           it 'returns record in order, leaving string untouched' do
             @order = Post.where(:title => 'title').order('title ASC')
             assert_equal ['title ASC'], @order.order_values


### PR DESCRIPTION
useful when passing order params from query params like

```
Person.order(params[:order] => params[:direction])
```