### PR TITLE
Do not load Globalize::XmlSerializer if ActiveRecord::XmlSerializer is not present

### DIFF
--- a/gemfiles/Gemfile.rails5
+++ b/gemfiles/Gemfile.rails5
@@ -2,9 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activemodel', '>= 5.0.0.rc1'
-gem 'activerecord', '>= 5.0.0.rc1'
-gem 'activemodel-serializers-xml'
+gem 'activemodel', '>= 5.0.0'
+gem 'activerecord', '>= 5.0.0'
 
 platforms :rbx do
   gem 'rubysl', '~> 2.0'

--- a/lib/patches/active_record/rails5/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails5/uniqueness_validator.rb
@@ -1,5 +1,3 @@
-require 'active_record/validations/uniqueness.rb'
-
 module Globalize
   module Validations
     module UniquenessValidator

--- a/lib/patches/active_record/xml_attribute_serializer.rb
+++ b/lib/patches/active_record/xml_attribute_serializer.rb
@@ -1,4 +1,7 @@
-require 'active_record/serializers/xml_serializer'
+begin
+  require 'active_record/serializers/xml_serializer'
+rescue LoadError
+end
 
 module Globalize
   module XmlSerializer
@@ -15,4 +18,6 @@ module Globalize
   end
 end
 
-ActiveRecord::XmlSerializer::Attribute.send(:prepend, Globalize::XmlSerializer::Attribute)
+if defined?(ActiveRecord::XmlSerializer)
+  ActiveRecord::XmlSerializer::Attribute.send(:prepend, Globalize::XmlSerializer::Attribute)
+end


### PR DESCRIPTION
Rails 5 has moved XML serializers in their own separate gem here

https://github.com/rails/activemodel-serializers-xml

globalize should work also if the Rails app does not use that gem