### PR TITLE
FIXED: 'false' values are returned as nil

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -46,7 +46,7 @@ module Globalize
         return super(name) unless options[:translated]
 
         if translated?(name)
-          if (value = globalize.fetch(options[:locale] || Globalize.locale, name))
+          if !(value = globalize.fetch(options[:locale] || Globalize.locale, name)).nil?
             value
           else
             super(name)

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -10,12 +10,15 @@ class AttributesTest < MiniTest::Spec
     end
 
     it 'returns the correct translation for a saved record after locale switching' do
-      post = Post.create(:title => 'title')
-      post.update_attributes(:title => 'Titel', :locale => :de)
+      post = Post.create(:title => 'title', published: false)
+      post.update_attributes(:title => 'Titel', :locale => :de, published: true)
       post.reload
 
       assert_translated post, :en, :title, 'title'
       assert_translated post, :de, :title, 'Titel'
+
+      assert_translated post, :en, :published, false
+      assert_translated post, :de, :published, true
     end
 
     # TODO: maybe move this somewhere else?


### PR DESCRIPTION
when a globalized attribute was 'false', the return value was nil.

See Code for details.