### PR TITLE
Update readme to make clear globalize usage with Rails 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ When using bundler put this in your Gemfile:
 gem 'globalize', '~> 5.0.0'
 ```
 
-To use globalize with Rails 5 add this in your Gemfile
+You have to use branch **master** to work with Rails 5.
+
+Put in your Gemfile
 
 ```ruby
+gem 'globalize', github: 'globalize/globalize'
 gem 'activemodel-serializers-xml'
 ```
 


### PR DESCRIPTION
I wasted about an hour until figured out that I should use Github version of gem to work with Rails 5. 

Updated accordingly to #527 