### PR TITLE
Fix array default values for PG

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -73,18 +73,7 @@ module Globalize
         if translation
           translation.send(name)
         else
-          column = column_for_attribute(name)
-          if column.respond_to?(:type_cast_from_database)
-            column.type_cast_from_database(column.default)
-          else
-            type = record.class.translation_class.type_for_attribute(name)
-            default = type.deserialize(column.default)
-            if default.nil?
-              "-> { #{column.default_function.inspect} }" if column.default_function
-            else
-              default
-            end
-          end
+          record.class.translation_class.new.send(name)
         end
       end
 


### PR DESCRIPTION
This fixes the following test that was disabled for Rails. The fix does not break the current test suite which is run against SQLite. However the test can not be reenabled because the schema can not be run against SQLite on Rails 5.

```ruby
  describe 'columns with default array value' do
    it 'returns the typecasted default value for arrays with empty array as default' do
      product = Product.new

      assert_equal [], product.array_values
    end
  end
```

I used this in test helpers to run tes test suite against PG, but unfortunately this broke many other tests and DatabaseCleaner :

```ruby
ActiveRecord::Tasks::PostgreSQLDatabaseTasks.new(adapter: 'postgresql', 'database' => 'globalize').purge
ActiveRecord::Base.establish_connection(adapter: 'postgresql', database: 'globalize')
```
