### PR TITLE
Fix destroying attributes in with_given_locale

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -12,11 +12,11 @@ module Globalize
       end
 
       def attributes=(attributes, *args)
-        with_given_locale(attributes) { super }
+        with_given_locale(attributes) { super(attributes_without_locale(attributes)) }
       end
 
       def assign_attributes(attributes, *args)
-        with_given_locale(attributes) { super }
+        with_given_locale(attributes) { super(attributes_without_locale(attributes)) }
       end
 
 
@@ -172,6 +172,10 @@ module Globalize
 
     protected
 
+      def attributes_without_locale(attributes)
+        attributes.try(:except, :locale)
+      end
+
       def each_locale_and_translated_attribute
         used_locales.each do |locale|
           translated_attribute_names.each do |name|
@@ -192,7 +196,7 @@ module Globalize
       end
 
       def with_given_locale(attributes, &block)
-        symbolized_attributes = attributes.symbolize_keys if attributes.respond_to?(:symbolize_keys!)
+        symbolized_attributes = attributes.symbolize_keys if attributes.respond_to?(:symbolize_keys)
 
         if locale = symbolized_attributes.try(:delete, :locale)
           Globalize.with_locale(locale, &block)

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -195,10 +195,11 @@ module Globalize
         translation_caches.clear
       end
 
-      def with_given_locale(attributes, &block)
-        symbolized_attributes = attributes.symbolize_keys if attributes.respond_to?(:symbolize_keys)
+      def with_given_locale(_attributes, &block)
+        attributes = _attributes.dup
+        attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys)
 
-        if locale = symbolized_attributes.try(:delete, :locale)
+        if locale = attributes.try(:delete, :locale)
           Globalize.with_locale(locale, &block)
         else
           yield

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -192,9 +192,9 @@ module Globalize
       end
 
       def with_given_locale(attributes, &block)
-        attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
+        symbolized_attributes = attributes.symbolize_keys if attributes.respond_to?(:symbolize_keys!)
 
-        if locale = attributes.try(:delete, :locale)
+        if locale = symbolized_attributes.try(:delete, :locale)
           Globalize.with_locale(locale, &block)
         else
           yield


### PR DESCRIPTION
### Summary

This fixes the behaviour of  arguments of ```assign_attributes```.
The original code destroy the arguments after assign_attributes.
If you use the same parameter after assign_attriubtes, it causes a lot of trouble. 

Given a case you have a User model applied globalize, the following problem happens.
```rb
params = {"id" => 1, "name" => "John Doe"}
user = User.find_or_initilized_by(id: params["id"])
user.assign_attributes(params)
params["id"]  # returns nil, whereas params[:id] = 1
```

I use this code in my project, and it made system problems.
This problem derived from the change in arguments in the with_given_locale method. 
This PR remains the original parameters and make a copy instead.

(This is my first pull request so allow me if something is wrong.)
