### PR TITLE
citext support for postgresql

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -153,7 +153,7 @@ module Globalize
         end
 
         def valid_field_type?(name, type)
-          !translated_attribute_names.include?(name) || [:string, :text].include?(type)
+          !translated_attribute_names.include?(name) || [:string, :text, :citext].include?(type)
         end
 
         def translation_index_name


### PR DESCRIPTION
Hi,

I am using Postgresql with citext extension (is an extension for case insensitive searchs), so.. i found that this gem is not supporting that type of data type and is a bit annoying failing a select because i searched for 'home' and the data is persisted as 'Home'.

I have tested in my fork in my project and just adding this PR, the field works, example:

BEFORE PR:
```
[8] pry(main)> Category.where(name: 'Home')
  Category Load (1.1ms)  SELECT "categories".* FROM "categories" INNER JOIN "category_translations" ON "category_translations"."category_id" = "categories"."id" WHERE "category_translations"."name" = 'Home' AND "category_translations"."locale" IN ('en', 'es')  ORDER BY "categories"."created_at" ASC
=> []
[9] pry(main)> Category.where(name: 'home')
  Category Load (2.7ms)  SELECT "categories".* FROM "categories" INNER JOIN "category_translations" ON "category_translations"."category_id" = "categories"."id" WHERE "category_translations"."name" = 'home' AND "category_translations"."locale" IN ('en', 'es')  ORDER BY "categories"."created_at" ASC
  Category::Translation Load (0.6ms)  SELECT "category_translations".* FROM "category_translations" WHERE "category_translations"."category_id" IN (1)
=> [#<Category:0x007faba1c87720
  id: 1,
  created_at: Tue, 09 Aug 2016 16:46:16 UTC +00:00,
  updated_at: Tue, 09 Aug 2016 16:46:16 UTC +00:00,
  product_category_id: 58>]
```

AFTER PR:
```
[4] pry(main)> Category.where(name: 'home')
  Category Load (1.5ms)  SELECT DISTINCT "categories".* FROM "categories" INNER JOIN "category_translations" ON "category_translations"."category_id" = "categories"."id" WHERE "category_translations"."locale" IN ('en', 'es') AND "category_translations"."name" = $1  ORDER BY "categories"."created_at" ASC  [["name", "home"]]
  Category::Translation Load (0.5ms)  SELECT "category_translations".* FROM "category_translations" WHERE "category_translations"."category_id" IN (1)
=> [#<Category:0x007ff0e51b6600
  id: 1,
  created_at: Tue, 09 Aug 2016 17:20:44 UTC +00:00,
  updated_at: Tue, 09 Aug 2016 17:20:44 UTC +00:00,
  product_category_id: 58>]
[5] pry(main)> Category.where(name: 'Home')
  Category Load (1.2ms)  SELECT DISTINCT "categories".* FROM "categories" INNER JOIN "category_translations" ON "category_translations"."category_id" = "categories"."id" WHERE "category_translations"."locale" IN ('en', 'es') AND "category_translations"."name" = $1  ORDER BY "categories"."created_at" ASC  [["name", "Home"]]
  Category::Translation Load (0.4ms)  SELECT "category_translations".* FROM "category_translations" WHERE "category_translations"."category_id" IN (1)
=> [#<Category:0x007ff0e50b6b10
  id: 1,
  created_at: Tue, 09 Aug 2016 17:20:44 UTC +00:00,
  updated_at: Tue, 09 Aug 2016 17:20:44 UTC +00:00,
  product_category_id: 58>]
```

regards,
juanma.