### PR TITLE
add inverse_of to translations association

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -79,7 +79,8 @@ module Globalize
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
-                                :autosave    => true
+                                :autosave    => true,
+                                :inverse_of  => :globalized_model
 
         before_create :save_translations!
         before_update :save_translations!

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -54,7 +54,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations
           klass
         end
       end


### PR DESCRIPTION
This fixes a validation error:

```
class Position < ApplicationRecord
  translates :name
end

> p = Position.new
> p.name = 'Position 1'
> p.valid?
false
> p.errors.full_messages
[
    [0] "Translations globalized model must exist"
]
```