### PR TITLE
Add 'optional: true' to belongs_to association

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -54,7 +54,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], optional: true
           klass
         end
       end


### PR DESCRIPTION
This fixes rails 5 belongs_to being required by default:

```
class Course < ApplicationRecord
  translates :title
end

course = Course.new(title: 'title')
course.save  # returns false
course.errors.full_messages  # returns Translations globalized model must exist
```