### PR TITLE
Add inverse_of to translations association (with passing test)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       gemfile: Gemfile
     - rvm: rbx
       gemfile: gemfiles/Gemfile.activemodel-serializers-xml.rb
+    - rvm: rbx
+      gemfile: gemfiles/Gemfile.rails-4.2.rb
     - rvm: jruby-9.1.2.0
       gemfile: Gemfile
     - rvm: jruby-9.1.2.0

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -79,7 +79,8 @@ module Globalize
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
-                                :autosave    => true
+                                :autosave    => true,
+                                :inverse_of  => :globalized_model
 
         before_create :save_translations!
         before_update :save_translations!

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -54,7 +54,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key]
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations
           klass
         end
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -79,6 +79,7 @@ module Globalize
 
           options[locale].each do |key, value|
             translation.send :"#{key}=", value
+            translation.globalized_model.send :"#{key}=", value
           end
           translation.save
         end


### PR DESCRIPTION
Continuing from #546. [This](https://github.com/globalize/globalize/blob/a7a33088e86b28e83fb296999672cfa7ba24e090/test/globalize/set_translations_test.rb#L33) spec of `set_translations` was failing because it sets an attribute on the translation, but the globalized model takes precedence. Haven't looked into it in any depth but this seems to fix it:

```ruby
options[locale].each do |key, value|
  translation.send :"#{key}=", value
  translation.globalized_model.send :"#{key}=", value
end
```

I just set the same attribute on `translation.globalized_model`, which passes the test.