### PR TITLE
WIP Get globalize working with Rubinius.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
-sudo: false
+sudo: required
+dist: trusty
 before_install: gem install bundler
 before_script: bundle exec rake db:create db:migrate
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,6 @@ gem "pry"
 
 eval File.read(File.expand_path("../gemfiles/.gemfile.database-config.rb", __FILE__))
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
     gem 'activerecord-jdbcsqlite3-adapter', github: "jruby/activerecord-jdbc-adapter"


### PR DESCRIPTION
On my macOS Sierra build of Rubinius 3.58, the following gist shows the results of `bundle && bundle exec rake db:create db:migrate && bundle exec rake`

https://gist.github.com/brixen/4da3f432677339d31a861e5962d10de9

Could someone provide a sanity check on this? Does it seem reasonable?

I'll continue to push commits until I see a green run on OSX and Ubuntu 14.04.