### PR TITLE
Drop locale index when dropping table

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -110,6 +110,9 @@ module Globalize
           if connection.indexes(translations_table_name).map(&:name).include?(translation_index_name)
             connection.remove_index(translations_table_name, :name => translation_index_name)
           end
+          if connection.indexes(translations_table_name).map(&:name).include?(translation_locale_index_name)
+            connection.remove_index(translations_table_name, :name => translation_locale_index_name)
+          end
         end
 
         def move_data_to_translation_table


### PR DESCRIPTION
Fixes #469.

Btw, the specs don't actually check that the method works, because in all DBs we are testing, dropping the table drops the indexes so removing them doesn't matter. But anyway, we should be removing them correctly, and I check that with this change we do that.