### PR TITLE
Add warning if using same columns on table and translations and clean up test data

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -49,7 +49,7 @@ module Globalize
       def check_columns!(attr_names)
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
-            ["These columns are present in both model and translation tables: #{overlap.join(', ')}\n",
+            ["These columns are present in both model and translation tables of #{model_name}: #{overlap.join(', ')}\n",
              "Globalize does not support this configuration, expect problems."].join
           )
         end

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -53,6 +53,8 @@ module Globalize
              "Globalize does not support this configuration, expect problems."].join
           )
         end
+      rescue ::ActiveRecord::StatementInvalid
+        warn "Model missing a table: #{model_name}"
       end
 
       def apply_globalize_options(options)

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -4,6 +4,7 @@ module Globalize
       def translates(*attr_names)
         options = attr_names.extract_options!
         # Bypass setup_translates! if the initial bootstrapping is done already.
+        check_columns!(attr_names)
         setup_translates!(options) unless translates?
 
         # Add any extra translatable attributes.
@@ -42,6 +43,15 @@ module Globalize
 
           # Add attribute to the list.
           self.translated_attribute_names << attr_name
+        end
+      end
+
+      def check_columns!(attr_names)
+        if (overlap = attr_names.map(&:to_s) & column_names).present?
+          ActiveSupport::Deprecation.warn(
+            ["These columns are present in both model and translation tables: #{overlap.join(', ')}\n",
+             "Globalize does not support this configuration, expect problems."].join
+          )
         end
       end
 

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -52,8 +52,10 @@ module Globalize
 
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
-            ["These columns are present in both model and translation tables of #{model_name}: #{overlap.join(', ')}\n",
-             "Globalize does not support this configuration, expect problems."].join
+            ["You have defined translated attributes with names that conflict with columns on the model table. ",
+             "Globalize does not support this configuration, remove or rename these columns.\n",
+             "Model name (table name): #{model_name} (#{table_name})\n",
+             "Attribute name(s): #{overlap.join(', ')}\n"].join
           )
         end
       end

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -4,8 +4,8 @@ module Globalize
       def translates(*attr_names)
         options = attr_names.extract_options!
         # Bypass setup_translates! if the initial bootstrapping is done already.
-        check_columns!(attr_names)
         setup_translates!(options) unless translates?
+        check_columns!(attr_names)
 
         # Add any extra translatable attributes.
         attr_names = attr_names.map(&:to_sym)
@@ -47,14 +47,15 @@ module Globalize
       end
 
       def check_columns!(attr_names)
+        # If tables do not exist, do not warn about conflicting columns
+        return unless table_exists? && translation_class.table_exists?
+
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
             ["These columns are present in both model and translation tables of #{model_name}: #{overlap.join(', ')}\n",
              "Globalize does not support this configuration, expect problems."].join
           )
         end
-      rescue ::ActiveRecord::StatementInvalid
-        warn "Model missing a table: #{model_name}"
       end
 
       def apply_globalize_options(options)

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -53,7 +53,7 @@ module Globalize
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
             ["You have defined translated attributes with names that conflict with columns on the model table. ",
-             "Globalize does not support this configuration, remove or rename these columns.\n",
+             "Globalize does not support this configuration anymore, remove or rename these columns.\n",
              "Model name (table name): #{model_name} (#{table_name})\n",
              "Attribute name(s): #{overlap.join(', ')}\n"].join
           )

--- a/test/data/models/account.rb
+++ b/test/data/models/account.rb
@@ -1,3 +1,0 @@
-class Account < ActiveRecord::Base
-  translates :notes
-end

--- a/test/data/models/bad_configuration.rb
+++ b/test/data/models/bad_configuration.rb
@@ -1,0 +1,5 @@
+ActiveSupport::Deprecation.silence do
+  class BadConfiguration < ActiveRecord::Base
+    translates :name
+  end
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -250,4 +250,14 @@ ActiveRecord::Schema.define do
     t.references :question
     t.string     :title, null: false
   end
+
+  create_table :bad_configurations, :force => true do |t|
+    t.string  :name
+  end
+
+  create_table :bad_configuration_translations, :force => true do |t|
+    t.integer :bad_configuration_id
+    t.string  :name
+    t.string  :locale
+  end
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define do
 
   create_table :posts, :force => true do |t|
     t.references :blog
-    t.boolean    :published
   end
 
   create_table :post_translations, :force => true do |t|
@@ -143,7 +142,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :tasks, :force => true do |t|
-    t.string   :name
     t.datetime :created_at
   end
 
@@ -154,7 +152,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :UPPERCASE_TABLE_NAME, :force => true do |t|
-    t.string :name
   end
 
   create_table :UPPERCASE_TABLE_NAME_translations, :force => true do |t|
@@ -164,7 +161,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :news, :force => true do |t|
-    t.string :title
   end
 
   create_table :news_translations, :force => true do |t|
@@ -184,7 +180,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :serialized_attrs, :force => true do |t|
-    t.text :meta
   end
 
   create_table :serialized_attr_translations, :force => true do |t|
@@ -194,25 +189,12 @@ ActiveRecord::Schema.define do
   end
 
   create_table :serialized_hashes, :force => true do |t|
-    t.text :meta
   end
 
   create_table :serialized_hash_translations, :force => true do |t|
     t.integer :serialized_hash_id
     t.string  :locale
     t.text    :meta
-  end
-
-  create_table :accounts, :force => true do |t|
-    t.string :business_name,  :null => false, :default => ""
-    t.string :notes, :null => false, :default => ""
-  end
-
-  create_table :account_translations, :force => true do |t|
-    t.references :account
-    t.string     :locale
-    t.string     :business_name
-    t.string     :notes
   end
 
   create_table :medias, :force => true do |t|
@@ -225,7 +207,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :model_with_custom_table_names, :force => true do |t|
-    t.string  :name
   end
 
   create_table :mctn_translations, :force => true do |t|

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -72,6 +72,11 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       User.find_by(args = { :name => 'foo' })
       assert_equal args, { :name => 'foo' }
     end
+
+    it 'handles case where translated attribute is in model table' do
+      bad_configuration = BadConfiguration.create(:name => "foo")
+      assert_equal bad_configuration, BadConfiguration.find_by(:name => "foo")
+    end
   end
 
   describe '.find_or_create_by' do


### PR DESCRIPTION
Looking through old issues, I noticed there are tons that are caused by the confusion around having translated columns in both the translations table and model table. A warning would help warn people that this is not a configuration Globalize supports.