### PR TITLE
Fix query methods for unsupported table configuration

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -39,6 +39,11 @@ module Globalize
           # Add attribute to the list.
           self.translated_attribute_names << attr_name
         end
+
+        if ::ActiveRecord::VERSION::STRING > "5.0" && table_exists? && translation_class.table_exists?
+          self.ignored_columns += translated_attribute_names.map(&:to_s)
+          reset_column_information
+        end
       end
 
       def check_columns!(attr_names)

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -7,10 +7,6 @@ module Globalize
         all.merge translation_class.with_locales(*locales)
       end
 
-      def with_where(opts = {})
-        all.merge translation_class.where(opts)
-      end
-
       def with_translations(*locales)
         locales = translated_locales if locales.empty?
         preload(:translations).joins(:translations).readonly(false).with_locales(locales).tap do |query|

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -3,6 +3,10 @@ module Globalize
     module ClassMethods
       delegate :translated_locales, :set_translations_table_name, :to => :translation_class
 
+      def columns_hash
+        super.except(*translated_attribute_names.map(&:to_s))
+      end
+
       def with_locales(*locales)
         all.merge translation_class.with_locales(*locales)
       end

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -3,8 +3,10 @@ module Globalize
     module ClassMethods
       delegate :translated_locales, :set_translations_table_name, :to => :translation_class
 
-      def columns_hash
-        super.except(*translated_attribute_names.map(&:to_s))
+      if ::ActiveRecord::VERSION::STRING < "5.0.0"
+        def columns_hash
+          super.except(*translated_attribute_names.map(&:to_s))
+        end
       end
 
       def with_locales(*locales)

--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -15,8 +15,7 @@ module Globalize
         if opts == :chain
           WhereChain.new(spawn)
         elsif parsed = parse_translated_conditions(opts)
-          #join_translations(super(parsed, *rest))
-          join_translations(super(parsed, *rest), opts)
+          join_translations(super(parsed, *rest))
         else
           super
         end
@@ -66,13 +65,12 @@ module Globalize
         end
       end
 
-      def join_translations(relation = self, opts = {})
+      def join_translations(relation = self)
         if relation.joins_values.include?(:translations)
-          rel = relation
+          relation
         else
-          rel = relation.with_translations_in_fallbacks
+          relation.with_translations_in_fallbacks
         end
-        rel.with_where(opts)
       end
 
       private

--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -14,13 +14,11 @@ module Globalize
       def where(opts = :chain, *rest)
         if opts == :chain
           WhereChain.new(spawn)
+        elsif parsed = parse_translated_conditions(opts)
+          #join_translations(super(parsed, *rest))
+          join_translations(super(parsed, *rest), opts)
         else
-          translated, normal = translated_vs_normal(opts)
-          if not translated.empty?
-            join_translations(super(normal, *rest), translated)
-          else
-            super
-          end
+          super
         end
       end
 
@@ -38,17 +36,6 @@ module Globalize
         else
           super
         end
-      end
-
-      def translated_vs_normal(opts)
-        translated = {}
-        if opts.is_a?(Hash) && respond_to?(:translated_attribute_names) && (opts.symbolize_keys.keys & translated_attribute_names).present?
-          opts = opts.dup
-          opts.each do |k,v|
-              translated[k] = opts.delete(k) || opts.delete(key.to_s) if translated_column? k.to_sym
-          end
-        end
-        return translated, opts
       end
 
       def with_translations_in_fallbacks

--- a/test/globalize/bad_configuration_test.rb
+++ b/test/globalize/bad_configuration_test.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+require File.expand_path('../../test_helper', __FILE__)
+
+class BadConfigurationTest < MiniTest::Spec
+  describe 'finders on data with bad configuration' do
+    it 'works with find_by' do
+      bad_configuration = BadConfiguration.create(:name => "foo")
+      assert_equal bad_configuration, BadConfiguration.find_by(:name => "foo")
+    end
+  end
+
+  describe '#columns_hash' do
+    it 'returns columns on model table minus translated attributes' do
+      assert_equal ["id"], BadConfiguration.columns_hash.keys
+    end
+  end
+end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -72,11 +72,6 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       User.find_by(args = { :name => 'foo' })
       assert_equal args, { :name => 'foo' }
     end
-
-    it 'handles case where translated attribute is in model table' do
-      bad_configuration = BadConfiguration.create(:name => "foo")
-      assert_equal bad_configuration, BadConfiguration.find_by(:name => "foo")
-    end
   end
 
   describe '.find_or_create_by' do


### PR DESCRIPTION
There have been many issues related to having columns on the model table with names that conflict with translated attributes (i.e. columns on the translations table), e.g. #423 and #458. #449 fixed one issue with `find_by`, but added duplication to the code and made it harder (for me anyway) to understand what is going on.

I added a regression spec in #557 to check that this fix is working, and in this PR I reverted the changes to query methods in #449 and replaced it with a single change, overriding `columns_hash` on the model table to remove translated attributes:

```ruby
def columns_hash
  super.except(*translated_attribute_names.map(&:to_s))
end
```

This fixes the [failing spec](https://github.com/ballistiq/globalize/blob/d972068192c0f74926f1755b4a39938dc4604d60/test/globalize/translated_attributes_query_test.rb#L76).

A more robust way to fix this would be to use [`ignored_columns`](https://github.com/rails/rails/pull/21720), but this is only available in Rails 5, and this issue appears to only manifest itself in Rails 4, so that's not really a solution.

Patching `columns_hash` seems like it might be risky... but all specs are passing, and I like it better than adding more complexity to our existing query method overrides, so I'm thinking this is okay. We could also limit it to Rails 4 only.

Any thoughts?