### PR TITLE
Fix assign_attributes, attributes=

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -11,12 +11,13 @@ module Globalize
         super.merge(translated_attributes)
       end
 
-      def attributes=(attributes, *args)
-        with_given_locale(attributes) { super(attributes_without_locale(attributes)) }
+      def attributes=(*args)
+        assign_attributes(*args)
       end
 
-      def assign_attributes(attributes, *args)
-        with_given_locale(attributes) { super(attributes_without_locale(attributes)) }
+      def assign_attributes(_attributes, *args)
+        attributes = _attributes.dup.symbolize_keys
+        with_given_locale(attributes) { super(attributes.except(:locale), *args) }
       end
 
       def write_attribute(name, value, options = {})
@@ -176,10 +177,6 @@ module Globalize
       end
 
     protected
-
-      def attributes_without_locale(attributes)
-        attributes.try(:except, :locale)
-      end
 
       def each_locale_and_translated_attribute
         used_locales.each do |locale|

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -11,13 +11,15 @@ module Globalize
         super.merge(translated_attributes)
       end
 
-      def attributes=(*args)
-        assign_attributes(*args)
+      def attributes=(new_attributes, *options)
+        return unless new_attributes.is_a?(Hash)
+        assign_attributes(new_attributes, *options)
       end
 
-      def assign_attributes(_attributes, *args)
-        attributes = _attributes.dup.symbolize_keys
-        with_given_locale(attributes) { super(attributes.except(:locale), *args) }
+      def assign_attributes(new_attributes, *options)
+        return unless new_attributes
+        attributes = new_attributes.symbolize_keys
+        with_given_locale(attributes) { super(attributes.except(:locale), *options) }
       end
 
       def write_attribute(name, value, options = {})
@@ -198,8 +200,7 @@ module Globalize
       end
 
       def with_given_locale(_attributes, &block)
-        attributes = _attributes.dup
-        attributes.symbolize_keys! if attributes.respond_to?(:symbolize_keys!)
+        attributes = _attributes.symbolize_keys
 
         if locale = attributes.try(:delete, :locale)
           Globalize.with_locale(locale, &block)

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -152,6 +152,27 @@ class AttributesTest < MiniTest::Spec
     end
   end
 
+  describe '#attributes=' do
+    it 'assigns translated attributes' do
+      post = Post.create(:title => 'title')
+      post.attributes = { :title => 'newtitle' }
+      assert_equal post.title, 'newtitle'
+      with_locale(:de) do
+        post.attributes = { :title => 'title in de' }
+        assert_equal post.title, 'title in de'
+      end
+      assert_equal post.title, 'newtitle'
+    end
+
+    it 'does not modify arguments passed in' do
+      post = Post.create(:title => 'title')
+      params = {'id' => 1, 'title' => 'newtitle', 'locale' => 'de'}
+      post.attributes = params
+      assert_equal params, {'id' => 1, 'title' => 'newtitle', 'locale' => 'de'}
+      with_locale(:de) { assert_equal post.title, 'newtitle' }
+    end
+  end
+
   describe '#assign_attributes' do
     it 'assigns translated attributes' do
       post = Post.create(:title => 'title')

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -164,6 +164,14 @@ class AttributesTest < MiniTest::Spec
       assert_equal post.title, 'newtitle'
     end
 
+    it 'does nothing if attributes is not a hash' do
+      post = Post.create(:title => 'title')
+      post.attributes = nil
+      assert_equal 'title', post.title
+      post.attributes = []
+      assert_equal 'title', post.title
+    end
+
     it 'does not modify arguments passed in' do
       post = Post.create(:title => 'title')
       params = {'id' => 1, 'title' => 'newtitle', 'locale' => 'de'}
@@ -183,6 +191,12 @@ class AttributesTest < MiniTest::Spec
         assert_equal post.title, 'title in de'
       end
       assert_equal post.title, 'newtitle'
+    end
+
+    it 'does nothing if attributes is nil' do
+      post = Post.create(:title => 'title')
+      post.assign_attributes(nil)
+      assert_equal 'title', post.title
     end
 
     it 'does not modify arguments passed in' do

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -152,6 +152,27 @@ class AttributesTest < MiniTest::Spec
     end
   end
 
+  describe '#assign_attributes' do
+    it 'assigns translated attributes' do
+      post = Post.create(:title => 'title')
+      post.assign_attributes(:title => 'newtitle')
+      assert_equal post.title, 'newtitle'
+      with_locale(:de) do
+        post.assign_attributes(:title => 'title in de')
+        assert_equal post.title, 'title in de'
+      end
+      assert_equal post.title, 'newtitle'
+    end
+
+    it 'does not modify arguments passed in' do
+      post = Post.create(:title => 'title')
+      params = {'id' => 1, 'title' => 'newtitle', 'locale' => 'de'}
+      post.assign_attributes(params)
+      assert_equal params, {'id' => 1, 'title' => 'newtitle', 'locale' => 'de'}
+      with_locale(:de) { assert_equal post.title, 'newtitle' }
+    end
+  end
+
   describe '#write_attribute' do
     it 'returns the value for non-translated attributes' do
       user = User.create(:name => 'Max Mustermann', :email => 'max@mustermann.de')
@@ -274,5 +295,4 @@ class AttributesTest < MiniTest::Spec
       assert_equal 'titolo', artwork.title(:it)
     end
   end
-
 end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -368,5 +368,11 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       assert_equal attachment, post.attachments.where(file_type: "image").first
       assert_equal attachment, blog.attachments.where(file_type: "image").first
     end
+
+    it 'creates record from relation' do
+      post = Post.create(:title => "title")
+      comment = post.translated_comments.where(content: "content").create
+      assert_equal 1, Comment.count
+    end
   end
 end


### PR DESCRIPTION
The fix in #537 and #545 to avoid modifying parameters passed to
`assign_attributes` and `attributes=` introduced a new bug, described in #559.
I added specs to check that parameters are not modified and fixed the bug in #559.

(Fixes #559.)