### PR TITLE
Fix assign attributes so it behaves like original

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -12,14 +12,15 @@ module Globalize
       end
 
       def attributes=(new_attributes, *options)
-        return unless new_attributes.is_a?(Hash)
-        assign_attributes(new_attributes, *options)
+        super unless new_attributes.respond_to?(:stringify_keys) && new_attributes.present?
+        attributes = new_attributes.stringify_keys
+        with_given_locale(attributes) { super(attributes.except("locale"), *options) }
       end
 
       def assign_attributes(new_attributes, *options)
-        return unless new_attributes
-        attributes = new_attributes.symbolize_keys
-        with_given_locale(attributes) { super(attributes.except(:locale), *options) }
+        super unless new_attributes.respond_to?(:stringify_keys) && new_attributes.present?
+        attributes = new_attributes.stringify_keys
+        with_given_locale(attributes) { super(attributes.except("locale"), *options) }
       end
 
       def write_attribute(name, value, options = {})
@@ -200,9 +201,9 @@ module Globalize
       end
 
       def with_given_locale(_attributes, &block)
-        attributes = _attributes.symbolize_keys
+        attributes = _attributes.stringify_keys
 
-        if locale = attributes.try(:delete, :locale)
+        if locale = attributes.try(:delete, "locale")
           Globalize.with_locale(locale, &block)
         else
           yield
@@ -216,7 +217,6 @@ module Globalize
       ensure
         self.fallbacks_for_empty_translations = before
       end
-
     end
   end
 end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -164,12 +164,10 @@ class AttributesTest < MiniTest::Spec
       assert_equal post.title, 'newtitle'
     end
 
-    it 'does nothing if attributes is not a hash' do
+    it 'raises ArgumentError if attributes is blank' do
       post = Post.create(:title => 'title')
-      post.attributes = nil
-      assert_equal 'title', post.title
-      post.attributes = []
-      assert_equal 'title', post.title
+      assert_raises(ArgumentError) { post.attributes = nil }
+      assert_raises(ArgumentError) { post.attributes = [] }
     end
 
     it 'does not modify arguments passed in' do
@@ -193,10 +191,10 @@ class AttributesTest < MiniTest::Spec
       assert_equal post.title, 'newtitle'
     end
 
-    it 'does nothing if attributes is nil' do
+    it 'raises ArgumentError if attributes is blank' do
       post = Post.create(:title => 'title')
-      post.assign_attributes(nil)
-      assert_equal 'title', post.title
+      assert_raises(ArgumentError) { post.assign_attributes(nil) }
+      assert_raises(ArgumentError) { post.assign_attributes([]) }
     end
 
     it 'does not modify arguments passed in' do


### PR DESCRIPTION
Should fix issue reported in #543.

@dalpo @fschwahn Please have a look, I think this should fix the strong parameters issue. I was looking at the source for the wrong version of Rails when I committed 4ea5cf7.