### PR TITLE
Get rid of alias_method_chain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,14 @@ end
 
 platforms :jruby do
   if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-    gem 'activerecord-jdbcsqlite3-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcsqlite3-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 
   if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
-    gem 'activerecord-jdbcmysql-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcmysql-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 
   if !ENV['TRAVIS'] || %w(postgres postgresql).include?(ENV['DB'])
-    gem 'activerecord-jdbcpostgresql-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcpostgresql-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 end

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You have to use branch **master** to work with Rails 5.
 Put in your Gemfile
 
 ```ruby
-gem 'globalize', github: 'globalize/globalize'
+gem 'globalize', git: 'https://github.com/globalize/globalize'
 gem 'activemodel-serializers-xml'
 ```
 
@@ -103,7 +103,7 @@ class CreatePosts < ActiveRecord::Migration
         Post.create_translation_table! :title => :string, :text => :text
       end
 
-      dir.down do 
+      dir.down do
         Post.drop_translation_table!
       end
     end
@@ -119,14 +119,14 @@ class CreatePosts < ActiveRecord::Migration
     create_table :posts do |t|
       t.timestamps
     end
-    
+
     reversible do |dir|
       dir.up do
         Post.create_translation_table! :title => :string,
           :text => {:type => :text, :null => false, :default => 'abc'}
       end
-      
-      dir.down do 
+
+      dir.down do
         Post.drop_translation_table!
       end
     end
@@ -161,8 +161,8 @@ class TranslatePosts < ActiveRecord::Migration
           :migrate_data => true
         })
       end
-      
-      dir.down do 
+
+      dir.down do
         Post.drop_translation_table! :migrate_data => true
       end
     end
@@ -217,8 +217,8 @@ class AddAuthorToPost < ActiveRecord::Migration
       dir.up do
         Post.add_translation_fields! author: :text
       end
-      
-      dir.down do 
+
+      dir.down do
         remove_column :post_translations, :author
       end
     end

--- a/gemfiles/Gemfile.activemodel-serializers-xml.rb
+++ b/gemfiles/Gemfile.activemodel-serializers-xml.rb
@@ -14,14 +14,14 @@ end
 
 platforms :jruby do
   if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-    gem 'activerecord-jdbcsqlite3-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcsqlite3-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 
   if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
-    gem 'activerecord-jdbcmysql-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcmysql-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 
   if !ENV['TRAVIS'] || %w(postgres postgresql).include?(ENV['DB'])
-    gem 'activerecord-jdbcpostgresql-adapter', github: "jruby/activerecord-jdbc-adapter"
+    gem 'activerecord-jdbcpostgresql-adapter', git: "https://github.com/jruby/activerecord-jdbc-adapter"
   end
 end

--- a/lib/patches/active_record/rails4/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails4/uniqueness_validator.rb
@@ -1,39 +1,42 @@
 require 'active_record/validations/uniqueness.rb'
 
-ActiveRecord::Validations::UniquenessValidator.class_eval do
-  def validate_each_with_translations(record, attribute, value)
-    klass = record.class
-    if klass.translates? && klass.translated?(attribute)
-      finder_class = klass.translation_class
-      table = finder_class.arel_table
+module Globalize
+  module UniquenessValidatorOverride
+    def validate_each(record, attribute, value)
+      klass = record.class
+      if klass.translates? && klass.translated?(attribute)
+        finder_class = klass.translation_class
+        table = finder_class.arel_table
 
-      relation = build_relation(finder_class, table, attribute, value).and(table[:locale].eq(Globalize.locale))
-      relation = relation.and(table[klass.reflect_on_association(:translations).foreign_key].not_eq(record.send(:id))) if record.persisted?
+        relation = build_relation(finder_class, table, attribute, value).and(table[:locale].eq(Globalize.locale))
+        relation = relation.and(table[klass.reflect_on_association(:translations).foreign_key].not_eq(record.send(:id))) if record.persisted?
 
-      translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
-      untranslated_scopes = Array(options[:scope]) - translated_scopes
+        translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
+        untranslated_scopes = Array(options[:scope]) - translated_scopes
 
-      untranslated_scopes.each do |scope_item|
-        scope_value = record.send(scope_item)
-        reflection = klass.reflect_on_association(scope_item)
-        if reflection
-          scope_value = record.send(reflection.foreign_key)
-          scope_item = reflection.foreign_key
+        untranslated_scopes.each do |scope_item|
+          scope_value = record.send(scope_item)
+          reflection = klass.reflect_on_association(scope_item)
+          if reflection
+            scope_value = record.send(reflection.foreign_key)
+            scope_item = reflection.foreign_key
+          end
+          relation = relation.and(find_finder_class_for(record).arel_table[scope_item].eq(scope_value))
         end
-        relation = relation.and(find_finder_class_for(record).arel_table[scope_item].eq(scope_value))
-      end
 
-      translated_scopes.each do |scope_item|
-        scope_value = record.send(scope_item)
-        relation = relation.and(table[scope_item].eq(scope_value))
-      end
+        translated_scopes.each do |scope_item|
+          scope_value = record.send(scope_item)
+          relation = relation.and(table[scope_item].eq(scope_value))
+        end
 
-      if klass.unscoped.with_translations.where(relation).exists?
-        record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
+        if klass.unscoped.with_translations.where(relation).exists?
+          record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
+        end
+      else
+        super
       end
-    else
-      validate_each_without_translations(record, attribute, value)
     end
   end
-  alias_method_chain :validate_each, :translations
 end
+
+ActiveRecord::Validations::UniquenessValidator.send :prepend, Globalize::UniquenessValidatorOverride


### PR DESCRIPTION
Instead, we can use Module#prepend

I've opted for the safer version which is to use `:send, :prepend` because this used to be a protected method in Ruby.
