### PR TITLE
Postgres sorting by translates attributes with fallbacks

### DIFF
--- a/test/globalize/order_test.rb
+++ b/test/globalize/order_test.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+require File.expand_path('../../test_helper', __FILE__)
+
+class OrderTest < MiniTest::Spec
+  before(:each) do
+    @previous_backend = I18n.backend
+    I18n.pretend_fallbacks
+    I18n.backend = BackendWithFallbacks.new
+
+    I18n.locale = :en
+    I18n.fallbacks = ::I18n::Locale::Fallbacks.new
+    I18n.fallbacks.map('en' => [ 'it' ])
+  end
+
+  after(:each) do
+    I18n.fallbacks.clear
+    I18n.hide_fallbacks
+    I18n.backend = @previous_backend
+  end
+
+  describe 'order' do
+    it "should be able to sort by a translated attribute with fallbacks" do
+      product = with_locale(:en) { Product.create(:name => 'first') }
+      product = with_locale(:it) { Product.create(:name => 'primo') }
+      assert_equal %w(first primo), Product.order(:name).map(&:name)
+    end
+  end
+end

--- a/test/globalize/order_test.rb
+++ b/test/globalize/order_test.rb
@@ -2,27 +2,48 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class OrderTest < MiniTest::Spec
-  before(:each) do
-    @previous_backend = I18n.backend
-    I18n.pretend_fallbacks
-    I18n.backend = BackendWithFallbacks.new
+  describe 'order with fallbacks' do
+    before(:each) do
+      @previous_backend = I18n.backend
+      I18n.pretend_fallbacks
+      I18n.backend = BackendWithFallbacks.new
 
-    I18n.locale = :en
-    I18n.fallbacks = ::I18n::Locale::Fallbacks.new
-    I18n.fallbacks.map('en' => [ 'it' ])
-  end
+      I18n.locale = :en
+      I18n.fallbacks = ::I18n::Locale::Fallbacks.new
+      I18n.fallbacks.map('en' => [ 'it' ])
 
-  after(:each) do
-    I18n.fallbacks.clear
-    I18n.hide_fallbacks
-    I18n.backend = @previous_backend
-  end
+      @first_product = with_locale(:en) { Product.create(:name => 'first') }
+      @second_product = with_locale(:it) { Product.create(:name => 'secondo') }
+    end
 
-  describe 'order' do
-    it "should be able to sort by a translated attribute with fallbacks" do
-      product = with_locale(:en) { Product.create(:name => 'first') }
-      product = with_locale(:it) { Product.create(:name => 'primo') }
-      assert_equal %w(first primo), Product.order(:name).map(&:name)
+    after(:each) do
+      I18n.fallbacks.clear
+      I18n.hide_fallbacks
+      I18n.backend = @previous_backend
+    end
+
+    it "should sort ascendand with a Symbol translated column" do
+      assert_equal %w(first secondo), Product.order(:name).map(&:name)
+    end
+
+    it "should sort ascendand with a Symbol translated column with a preset selection" do
+      assert_equal %w(first secondo), Product.select(:id).order(:name).map(&:name)
+    end
+
+    it "should sort ascendand with a Hash translated column" do
+      assert_equal %w(first secondo), Product.order({:name => :asc}).map(&:name)
+    end
+
+    it "should sort descendand with a Hash translated column" do
+      assert_equal %w(secondo first), Product.order({:name => :desc}).map(&:name)
+    end
+
+    it "should sort ascendand with a Hash translated column with a preset selection" do
+      assert_equal %w(first secondo), Product.select(:id).order({:name => :asc}).map(&:name)
+    end
+
+    it "should sort descendand with a Hash translated column with a preset selection" do
+      assert_equal %w(secondo first), Product.select(:id).order({:name => :desc}).map(&:name)
     end
   end
 end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -185,7 +185,13 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
         describe 'for translated columns' do
           it 'returns record in order, column as symbol' do
             @order = Post.where(:title => 'title').order(:title)
-            assert_equal ['post_translations.title'], @order.order_values
+
+            case Globalize::Test::Database.driver
+            when 'mysql'
+              assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
+            else
+              assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
+            end
           end
 
           it 'returns record in order, column and direction as hash' do


### PR DESCRIPTION
Sorting translated attributes with enabled fallbacks is causing an `ActiveRecord::StatementInvalid: PG::InvalidColumnReference: ERROR` on postgres.
#### SQL Error:

```
SELECT DISTINCT, ORDER BY expressions must appear in select list
```
#### Issue history:
- [Added uniq to with_translations to prevent duplicates when fallbacks are defined #489](https://github.com/globalize/globalize/pull/489)
- [Fix: use DISTINCT query only if necessary](https://github.com/globalize/globalize/commit/3610db4cb2447b3ea25d64bf0682dc9704623e47)
- [uniq clause breaks default scope with SQL function](https://github.com/globalize/globalize/issues/519)
