### PR TITLE
Fix stack level too deep error on _reset_attribute

### DIFF
--- a/lib/globalize/active_record/adapter_dirty.rb
+++ b/lib/globalize/active_record/adapter_dirty.rb
@@ -41,8 +41,9 @@ module Globalize
       end
 
       def _reset_attribute name
-        record.send("#{name}=", record.changed_attributes[name])
+        old_value = record.changed_attributes[name]
         record.original_changed_attributes.except!(name)
+        record.send("#{name}=", old_value)
       end
 
       def reset


### PR DESCRIPTION
I found `stack level too deep` error due to AdapterDirty#_reset_attribute logic:
`record.send("#{name}=", record.changed_attributes[name])` called before `changed_attributes` reset so we have another `_reset_attribute` call and endless recursion
https://github.com/globalize/globalize/blob/master/lib/globalize/active_record/adapter_dirty.rb#L44
https://github.com/globalize/globalize/blob/master/lib/globalize/active_record/adapter_dirty.rb#L16