### PR TITLE
Remove unused adapter translations accessor and versioning method

### DIFF
--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -3,7 +3,7 @@ module Globalize
     class Adapter
       # The cache caches attributes that already were looked up for read access.
       # The stash keeps track of new or changed values that need to be saved.
-      attr_accessor :record, :stash, :translations
+      attr_accessor :record, :stash
       private :record=, :stash=
 
       delegate :translation_class, :to => :'record.class'

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -142,10 +142,6 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      def rollback
-        translation_caches[::Globalize.locale] = translation.previous_version
-      end
-
       def save(*)
         result = Globalize.with_locale(translation.locale || I18n.default_locale) do
           without_fallbacks do


### PR DESCRIPTION
While poking around the stash/cache, noticed that `Adapter#translations` is not being used, and also that we have a `rollback` method which depends on `paper_trail` which should not be here anymore (versioning stuff has been moved to [globalize-versioning](https://github.com/globalize/globalize-versioning).