### PR TITLE
Improve warning message about conflicting table columns

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -52,8 +52,8 @@ module Globalize
 
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
-            ["You have defined translated attributes with names that conflict with columns on the model table. ",
-             "Globalize does not support this configuration anymore, remove or rename these columns.\n",
+            ["You have defined one or more translated attributes with names that conflict with column(s) on the model table. ",
+             "Globalize does not support this configuration anymore, remove or rename column(s) on the model table.\n",
              "Model name (table name): #{model_name} (#{table_name})\n",
              "Attribute name(s): #{overlap.join(', ')}\n"].join
           )


### PR DESCRIPTION
The current message is not clear that it is the column on the *model* table that needs to be fixed.

Related: #574