### PR TITLE
Don't create translation record for default_locale on save (rebased)

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -143,7 +143,7 @@ module Globalize
       end
 
       def save(*)
-        result = Globalize.with_locale(translation.locale || I18n.default_locale) do
+        result = Globalize.with_locale(Globalize.locale || I18n.default_locale) do
           without_fallbacks do
             super
           end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -376,4 +376,34 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
       assert_equal 1, Comment.count
     end
   end
+
+  describe "without a record for default locale" do
+    before do
+      @artwork = Artwork.new
+    end
+
+    it "doesn't create translation for default locale on save" do
+      @artwork.translations.build(locale: :de, title: "Titel")
+      @artwork.save
+
+      assert_equal 1, @artwork.translations.count
+      assert_equal :de, @artwork.translations.first.locale
+    end
+
+    it "doesn't create any translation on save" do
+      @artwork.save
+
+      assert_equal 0, @artwork.translations.count
+    end
+
+    it "creates a translation for default locale after the assignment of translated attributes" do
+      @artwork.save
+      @artwork.title = "Title"
+      @artwork.save
+
+      assert_equal 1, @artwork.translations.count
+      assert_equal :en, @artwork.translations.first.locale
+      assert_equal "Title", @artwork.title
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/globalize/globalize/pull/328 rebased to master and working. Only 1 spec is failing - imho its okay to change the spec, but maybe if u prefer to have some backwards compability config option, we could do it as well.