### PR TITLE
Fix warning

### DIFF
--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -118,9 +118,8 @@ class AttributesTest < MiniTest::Spec
 
     it 'does not change untranslated value' do
       post = Post.create(:title => 'title')
-      before = post.untranslated_attributes['title']
       post.title = 'changed title'
-      assert_equal post.untranslated_attributes['title'], before
+      assert_nil post.untranslated_attributes['title']
     end
 
     it 'does not remove secondary unsaved translations' do
@@ -247,7 +246,7 @@ class AttributesTest < MiniTest::Spec
   describe 'serializable attribute' do
     it 'works with default marshalling, without data' do
       model = SerializedAttr.create
-      assert_equal nil, model.meta
+      assert_nil model.meta
     end
 
     it 'works with default marshalling, with data' do

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -76,7 +76,7 @@ class DirtyTrackingTest < MiniTest::Spec
       post.save
 
       I18n.locale = :de
-      assert_equal nil, post.title
+      assert_nil post.title
 
       post.title = 'Titel'
       assert_equal({ 'title' => [nil, 'Titel'] }, post.changes)

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -366,7 +366,7 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
 
     it 'creates record from relation' do
       post = Post.create(:title => "title")
-      comment = post.translated_comments.where(content: "content").create
+      post.translated_comments.where(content: "content").create
       assert_equal 1, Comment.count
     end
   end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -139,9 +139,9 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
     end
 
     it 'handles nil case' do
-      assert_equal nil, Post.where(:title => 'foo').first
-      assert_equal nil, Post.where(:title => 'foo').last
-      assert_equal nil, Post.where(:title => 'foo').take
+      assert_nil Post.where(:title => 'foo').first
+      assert_nil Post.where(:title => 'foo').last
+      assert_nil Post.where(:title => 'foo').take
     end
 
     describe '.first' do
@@ -327,7 +327,7 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
 
       # find_by
       assert_equal post, Post.find_by(:title  => 'タイトル')
-      assert_equal nil, Post.find_by(:title => 'titre')
+      assert_nil Post.find_by(:title => 'titre')
 
       # exists
       assert Post.exists?(:title => 'タイトル')


### PR DESCRIPTION
Fixed warning on test execution.
* Remove unused variable
* Use assert_nil instead of expecting nil