### PR TITLE
Clone relation that raises immutability exception (fixes #531)

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -3,7 +3,7 @@ module Globalize
     module QueryMethods
       class WhereChain < ::ActiveRecord::QueryMethods::WhereChain
         def not(opts, *rest)
-          if parsed = @scope.parse_translated_conditions(opts)
+          if parsed = @scope.clone.parse_translated_conditions(opts)
             @scope.join_translations.where.not(parsed, *rest)
           else
             super

--- a/test/globalize/dont_modify_immutable_relation_test.rb
+++ b/test/globalize/dont_modify_immutable_relation_test.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+require File.expand_path('../../test_helper', __FILE__)
+
+class DontModifyImmutableRelationTest < MiniTest::Spec
+  describe 'going through has_many :through relation and where.not condition' do
+    it "does not raises ActiveRecord::ImmutableRelation" do
+      # This should not raise ActiveRecord::ImmutableRelation
+      Author.new.comments_without_translations.where.not(content: 'anything really')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes an issue where going through a `has_many :through` relation with a `where.not`
condition triggers a Deprecation warning in rails 4 and raises an exception in rails 5. More details
in the issue #531.

Let me know if the (light) aproach to testing it was ok.