### PR TITLE
Require Ruby version 2.0 or higher

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'activerecord', '>= 4.2', '< 5.1'
   s.add_dependency 'activemodel', '>= 4.2', '< 5.1'


### PR DESCRIPTION
Prompted by https://github.com/globalize/globalize/pull/569, which makes use of `Module#prepend`, which is a Ruby 2+ method.