### PR TITLE
Fix for postgres: remove a column only if exists

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -53,7 +53,12 @@ module Globalize
         end
 
         def remove_source_columns
-          connection.remove_columns(table_name, *fields.keys)
+          column_names = *fields.keys
+          column_names.each do |column|
+            if connection.column_exists?(table_name, column)
+              connection.remove_column(table_name, column)
+            end
+          end
         end
 
         def drop_translation_table!(options = {})


### PR DESCRIPTION
This is a fix for Postgres (haven't tried others) when trying to remove a column that does not exist. 

This is caused by the config `remove_source_columns: true` leading to this error

```
PG::UndefinedColumn: ERROR:  column "title" of relation "books" does not exist
: ALTER TABLE "books" DROP "title"
```
