### PR TITLE
Ensure returned records have the correct ID when ordering

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -86,7 +86,7 @@ module Globalize
         # Inject `full_column` to the select values to avoid
         # PG::InvalidColumnReference errors with distinct queries on Postgres
         if select_values.empty?
-          self.select_values = [Arel.star, full_column]
+          self.select_values = [self.arel_table[Arel.star], full_column]
         else
           self.select_values << full_column
         end

--- a/test/globalize/order_test.rb
+++ b/test/globalize/order_test.rb
@@ -45,5 +45,12 @@ class OrderTest < MiniTest::Spec
     it "should sort descendand with a Hash translated column with a preset selection" do
       assert_equal %w(secondo first), Product.select(:id).order({:name => :desc}).map(&:name)
     end
+
+    it "should not return products with ID from translations table" do
+      with_locale(:fr) { @first_product.update_attributes(name: 'premier') }
+      premier_product = with_locale(:fr) { Product.order(name: :asc).first }
+      assert_equal @first_product.name, premier_product.name, 'products should be the same record as shown by their default name'
+      assert_equal @first_product, premier_product, 'returned product records should have the same ID from the products table'
+    end
   end
 end


### PR DESCRIPTION
In f1f1628f, the `Arel.star` used, would mean that *all* columns from the source table and joined tables get returned. This meant that there were multiple columns with the name "id". It appears that ActiveRecord will use the latest "id" column to populate the attribute of the returned record.

This is a problem when the IDs of the translation records don't match the ID of the source model, which is almost always the case outside of these simple tests. To demonstrate this, we only need to create a new translation for a model, and then build a query that finds it with that ID-differing locale.

I believe the fix is simple; rather than producing queries of the form `SELECT DISTINCT *, product_translations.name FROM ...`, we just need to only request the source table columns: `SELECT DISTINCT products.*, product_translations.name FROM ...`.