### PR TITLE
make touch: true an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ Because globalize uses the `:locale` key to specify the locale during
 mass-assignment, you should avoid having a `locale` attribute on the parent
 model.
 
+If you like your translated model to update if a translation changes, use the `touch: true` option together with `translates`:
+
+```ruby
+  translates :name, touch: true
+```
+
 ## Known Issues
 
 If you're getting the `ActiveRecord::StatementInvalid: PG::NotNullViolation: ERROR: null value in column "column_name" violates not-null constraint` error, the only known way to deal with it as of now is to remove not-null constraint for the globalized columns:

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -56,7 +56,11 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations, touch: translation_options[:touch] || false
+          klass.belongs_to :globalized_model, 
+            :class_name => self.name, 
+            :foreign_key => translation_options[:foreign_key], 
+            inverse_of: :translations, 
+            touch: translation_options.fetch(:touch, false)
           klass
         end
       end

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -56,7 +56,7 @@ module Globalize
             klass = self.const_set(:Translation, Class.new(Globalize::ActiveRecord::Translation))
           end
 
-          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations
+          klass.belongs_to :globalized_model, :class_name => self.name, :foreign_key => translation_options[:foreign_key], inverse_of: :translations, touch: translation_options[:touch] || false
           klass
         end
       end


### PR DESCRIPTION
Makes the touch: true an option. In the past `touch: true` was standard, which was removed because of this rails issue https://github.com/rails/rails/pull/9448, which should be fixed. I also updated the readme.