### PR TITLE
Bump rails dependency versions to '< 5.2'

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'activerecord', '>= 4.2', '< 5.1'
-  s.add_dependency 'activemodel', '>= 4.2', '< 5.1'
+  s.add_dependency 'activerecord', '>= 4.2', '< 5.2'
+  s.add_dependency 'activemodel', '>= 4.2', '< 5.2'
   s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
This gem has been working fine with the Rails 5.1 RC releases.  Now that 5.1 final is released I assume that globalize will be compatible until at least 5.2.