### PR TITLE
add vulgata link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,3 +434,5 @@ If you're not using Rails, you may need to consult a RequestStore's [README](htt
 ## Related solutions
 
 * [friendly_id-globalize](https://github.com/norman/friendly_id-globalize) - lets you use Globalize to translate slugs (Norman Clarke)
+
+* [Vulgata](https://github.com/kaipule-tech/vulgata) - A Rails engine that creates a fully functional translation center for your data (using Globalize) and I18n keys.


### PR DESCRIPTION
Hey guys.
We've developed this tool and have been using it for the past few months to translate and manage our translations in-house. Thought I should add a link to it in the "related solutions" section in the readme.