### PR TITLE
Support for Rails 5.1

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -46,6 +46,7 @@ module Globalize
             reset_column_information
           end
         rescue ::ActiveRecord::NoDatabaseError
+          warn 'Unable to connect to a database. Globalize skipped ignoring columns of translated attributes.'
         end
       end
 
@@ -61,6 +62,7 @@ module Globalize
           )
         end
       rescue ::ActiveRecord::NoDatabaseError
+        warn 'Unable to connect to a database. Globalize skipped checking attributes with conflicting column names.'
       end
 
       def apply_globalize_options(options)

--- a/lib/patches/active_record/rails5_1/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails5_1/uniqueness_validator.rb
@@ -1,0 +1,46 @@
+module Globalize
+  module Validations
+    module UniquenessValidator
+      def validate_each(record, attribute, value)
+        klass = record.class
+        if klass.translates? && klass.translated?(attribute)
+          finder_class = klass.translation_class
+          relation = build_relation(finder_class, attribute, value).where(locale: Globalize.locale)
+          relation = relation.where.not(klass.reflect_on_association(:translations).foreign_key => record.send(:id)) if record.persisted?
+
+
+          translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
+          untranslated_scopes = Array(options[:scope]) - translated_scopes
+
+          relation = relation.joins(:globalized_model) if untranslated_scopes.present?
+          untranslated_scopes.each do |scope_item|
+            scope_value = record.send(scope_item)
+            reflection = klass.reflect_on_association(scope_item)
+            if reflection
+              scope_value = record.send(reflection.foreign_key)
+              scope_item = reflection.foreign_key
+            end
+            relation = relation.where(find_finder_class_for(record).table_name => { scope_item => scope_value })
+          end
+
+          translated_scopes.each do |scope_item|
+            scope_value = record.send(scope_item)
+            relation = relation.where(scope_item => scope_value)
+          end
+          relation = relation.merge(options[:conditions]) if options[:conditions]
+
+          # if klass.unscoped.with_translations.where(relation).exists?
+          if relation.exists?
+            error_options = options.except(:case_sensitive, :scope, :conditions)
+            error_options[:value] = value
+            record.errors.add(attribute, :taken, error_options)
+          end
+        else
+          super(record, attribute, value)
+        end
+      end
+    end
+  end
+end
+
+ActiveRecord::Validations::UniquenessValidator.prepend Globalize::Validations::UniquenessValidator

--- a/lib/patches/active_record/rails5_1/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails5_1/uniqueness_validator.rb
@@ -29,7 +29,6 @@ module Globalize
           end
           relation = relation.merge(options[:conditions]) if options[:conditions]
 
-          # if klass.unscoped.with_translations.where(relation).exists?
           if relation.exists?
             error_options = options.except(:case_sensitive, :scope, :conditions)
             error_options[:value] = value

--- a/lib/patches/active_record/uniqueness_validator.rb
+++ b/lib/patches/active_record/uniqueness_validator.rb
@@ -1,5 +1,7 @@
 if ::ActiveRecord::VERSION::STRING < "5.0.0"
   require_relative 'rails4/uniqueness_validator'
-else
+elsif ::ActiveRecord::VERSION::STRING < "5.1.0"
   require_relative 'rails5/uniqueness_validator'
+else
+  require_relative 'rails5_1/uniqueness_validator'
 end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -258,7 +258,11 @@ class AttributesTest < MiniTest::Spec
 
     it 'works with specified marshalling, without data, rails 5.0+' do
       model = SerializedHash.new
-      assert_equal nil, model.meta
+      if ::ActiveRecord::VERSION::STRING < "5.0"
+        assert_equal Hash.new, model.meta
+      else
+        assert_equal nil, model.meta
+      end
     end
   end
 

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -256,9 +256,9 @@ class AttributesTest < MiniTest::Spec
       assert_equal data, model.meta
     end
 
-    it 'works with specified marshalling, without data, rails 3.1+' do
+    it 'works with specified marshalling, without data, rails 5.0+' do
       model = SerializedHash.new
-      assert_equal Hash.new, model.meta
+      assert_equal nil, model.meta
     end
   end
 


### PR DESCRIPTION
There was a change in a private method called `build_relation` in Rails 5.1. I added an updated `uniqueness_validator.rb` in `lib/patches`.