### PR TITLE
Resolve deprecation warning: attribute is not an attribute known to AR.

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -98,6 +98,7 @@ module Globalize
       end
 
       def define_translated_attr_accessor(name)
+        attribute(name)
         define_translated_attr_reader(name)
         define_translated_attr_writer(name)
       end


### PR DESCRIPTION
this warning:
```
DEPRECATION WARNING: {attribute} is not an attribute known to Active Record. This behavior is deprecated and will be removed in the next version of Rails. If you'd like name to be managed by Active Record, add `attribute :name to your class.
```
will resolved with this fix.