### PR TITLE
Fix ActiveRecord serialize default coder values for Rails 5+

### DIFF
--- a/lib/patches/active_record/rails4/serialization.rb
+++ b/lib/patches/active_record/rails4/serialization.rb
@@ -1,0 +1,22 @@
+module Globalize
+  module AttributeMethods
+    module Serialization
+      def serialize(attr_name, class_name_or_coder = Object)
+        super(attr_name, class_name_or_coder)
+
+        coder = if class_name_or_coder == ::JSON
+                  ::ActiveRecord::Coders::JSON
+                elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
+                  class_name_or_coder
+                else
+                  ::ActiveRecord::Coders::YAMLColumn.new(class_name_or_coder)
+                end
+
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = coder
+      end
+    end
+  end
+end
+
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/lib/patches/active_record/rails5_1/serialization.rb
+++ b/lib/patches/active_record/rails5_1/serialization.rb
@@ -1,0 +1,22 @@
+module Globalize
+  module AttributeMethods
+    module Serialization
+      def serialize(attr_name, class_name_or_coder = Object)
+        super(attr_name, class_name_or_coder)
+
+        coder = if class_name_or_coder == ::JSON
+                  ::ActiveRecord::Coders::JSON
+                elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
+                  class_name_or_coder
+                else
+                  ::ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
+                end
+
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = coder
+      end
+    end
+  end
+end
+
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,22 +1,5 @@
-module Globalize
-  module AttributeMethods
-    module Serialization
-      def serialize(attr_name, class_name_or_coder = Object)
-        super(attr_name, class_name_or_coder)
-
-        coder = if class_name_or_coder == ::JSON
-                  ::ActiveRecord::Coders::JSON
-                elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
-                  class_name_or_coder
-                else
-                  ::ActiveRecord::Coders::YAMLColumn.new(class_name_or_coder)
-                end
-
-        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
-        self.globalize_serialized_attributes[attr_name] = coder
-      end
-    end
-  end
+if ::ActiveRecord::VERSION::STRING < "5.1.0"
+  require_relative 'rails4/serialization'
+else
+  require_relative 'rails5_1/serialization'
 end
-
-ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/test/data/models/serialized_attr.rb
+++ b/test/data/models/serialized_attr.rb
@@ -3,7 +3,14 @@ class SerializedAttr < ActiveRecord::Base
   translates :meta
 end
 
-class JSONSerializedAttr < SerializedAttr
+class ArraySerializedAttr < ActiveRecord::Base
+  self.table_name = 'serialized_attrs'
+  serialize :meta, Array
+  translates :meta
+end
+
+class JSONSerializedAttr < ActiveRecord::Base
+  self.table_name = 'serialized_attrs'
   serialize :meta, JSON
   translates :meta
 end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -248,6 +248,7 @@ class AttributesTest < MiniTest::Spec
     it 'keeps track of serialized attributes between classes' do
       assert_equal UnserializedAttr.globalize_serialized_attributes, {}
       assert_equal SerializedAttr.globalize_serialized_attributes[:meta].class, ActiveRecord::Coders::YAMLColumn
+      assert_equal ArraySerializedAttr.globalize_serialized_attributes[:meta].class, ActiveRecord::Coders::YAMLColumn
       assert_equal JSONSerializedAttr.globalize_serialized_attributes[:meta], ActiveRecord::Coders::JSON
     end
 
@@ -262,13 +263,14 @@ class AttributesTest < MiniTest::Spec
       assert_equal data, model.meta
     end
 
-    it 'works with specified marshalling, without data, rails 5.0+' do
+    it 'works with Hash marshalling, without data' do
       model = SerializedHash.new
-      if ::ActiveRecord::VERSION::STRING < "5.0"
-        assert_equal Hash.new, model.meta
-      else
-        assert_equal nil, model.meta
-      end
+      assert_equal Hash.new, model.meta
+    end
+
+    it 'works with Array marshalling, without data' do
+      model = ArraySerializedAttr.new
+      assert_equal Array.new, model.meta
     end
   end
 


### PR DESCRIPTION
Fix `Globalize::AttributeMethods::Serialization` to accommodate new ActiveRecord 5+ `Coders::YAMLColumn#initialize` signature. It now takes both the `attr_name` and `class_name_or_coder`, where in ActiveRecord < 5 it only took the `class_name_or_coder`. 

Added a unit test to ensure `Coders::YAMLColumn` serialized column returns correct Array.new default value when DB value is NULL. Updated the 'works with specified marshalling, without data, rails 5.0+' test to reflect changes, both Rails 4 and 5 should return a `Hash.new` in case DB value is NULL and column is serialized as `Hash`.