### PR TITLE
Fix MiniTest deprecation warnings

### DIFF
--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -118,9 +118,9 @@ class AttributesTest < MiniTest::Spec
 
     it 'does not change untranslated value' do
       post = Post.create(:title => 'title')
-      before = post.untranslated_attributes['title']
+      assert_nil post.untranslated_attributes['title']
       post.title = 'changed title'
-      assert_equal post.untranslated_attributes['title'], before
+      assert_nil post.untranslated_attributes['title']
     end
 
     it 'does not remove secondary unsaved translations' do

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -254,7 +254,7 @@ class AttributesTest < MiniTest::Spec
 
     it 'works with default marshalling, without data' do
       model = SerializedAttr.create
-      assert_equal nil, model.meta
+      assert_nil model.meta
     end
 
     it 'works with default marshalling, with data' do

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -76,7 +76,7 @@ class DirtyTrackingTest < MiniTest::Spec
       post.save
 
       I18n.locale = :de
-      assert_equal nil, post.title
+      assert_nil post.title
 
       post.title = 'Titel'
       assert_equal({ 'title' => [nil, 'Titel'] }, post.changes)
@@ -99,7 +99,7 @@ class DirtyTrackingTest < MiniTest::Spec
       assert_equal({ 'title' => ['title', nil] }, post.changes)
       post.save
     end
-    
+
     it 'works for assigning new value == old value of other locale' do
       post = Post.create(:title => nil, :content => 'content')
       # assert_equal [], post.changed

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -139,9 +139,9 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
     end
 
     it 'handles nil case' do
-      assert_equal nil, Post.where(:title => 'foo').first
-      assert_equal nil, Post.where(:title => 'foo').last
-      assert_equal nil, Post.where(:title => 'foo').take
+      assert_nil Post.where(:title => 'foo').first
+      assert_nil Post.where(:title => 'foo').last
+      assert_nil Post.where(:title => 'foo').take
     end
 
     describe '.first' do
@@ -333,7 +333,7 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
 
       # find_by
       assert_equal post, Post.find_by(:title  => 'タイトル')
-      assert_equal nil, Post.find_by(:title => 'titre')
+      assert_nil Post.find_by(:title => 'titre')
 
       # exists
       assert Post.exists?(:title => 'タイトル')
@@ -372,7 +372,7 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
 
     it 'creates record from relation' do
       post = Post.create(:title => "title")
-      comment = post.translated_comments.where(content: "content").create
+      post.translated_comments.where(content: "content").create
       assert_equal 1, Comment.count
     end
   end

--- a/test/support/database.yml
+++ b/test/support/database.yml
@@ -1,16 +1,17 @@
 mysql:
   adapter: mysql2
+  host: localhost
+  port: 3306
   database: globalize_test
   username: root
-  hostname: localhost
   encoding: utf8
 
 postgres:
   adapter: postgresql
   host: localhost
   port: 5432
-  username: postgres
   database: globalize_test
+  username: postgres
   encoding: utf8
 
 sqlite3:


### PR DESCRIPTION
Hi! I'm working on debuging https://github.com/globalize/globalize/pull/629 and found this warnings.
Thank you!