### PR TITLE
Set MySQL DB encoding to UTF8 in test environment

### DIFF
--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -55,7 +55,7 @@ module Globalize
         db_config = config[driver]
         command = case driver
         when "mysql"
-          "mysql -u #{db_config['username']} -e 'create database #{db_config['database']};' >/dev/null"
+          "mysql -u #{db_config['username']} -e 'create database #{db_config['database']} character set utf8 collate utf8_general_ci;' >/dev/null"
         when "postgres", "postgresql"
           "psql -c 'create database #{db_config['database']};' -U #{db_config['username']} >/dev/null"
         end


### PR DESCRIPTION
It should fix errors in Travis : https://travis-ci.org/globalize/globalize/jobs/327791954

```
ActiveRecord::StatementInvalid: ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect string value: '\xE3\x82\xBF\xE3\x82\xA4...' for column 'title' at row 1: INSERT INTO `post_translations` (`locale`, `post_id`, `title`) VALUES ('ja', 1, 'タイトル1')
 ```