### PR TITLE
Update InstanceMethods#changed? to remove Rails deprecation warning

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -166,7 +166,7 @@ module Globalize
       end
 
       def changed?
-        changed_attributes.present? || translations.any?(&:changed?)
+        saved_changes.transform_values(&:first).present? || translations.any?(&:changed?)
       end
 
       # need to access instance variable directly since changed_attributes

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -114,6 +114,7 @@ class AttributesTest < MiniTest::Spec
       post.save
       assert post.translations.all?(&:persisted?)
       assert_equal 1, post.translations.length
+      assert post.changed?
     end
 
     it 'does not change untranslated value' do


### PR DESCRIPTION
This PR removes the usage of `changed_attributes` for the ActiveRecord override `changed?` under Rails 5.1, to remove generated deprecation warnings similar to:

> DEPRECATION WARNING: The behavior of `changed_attributes` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_changes.transform_values(&:first)` instead. (called from changed? at /Users/user/.rvm/gems/ruby-2.3.3/bundler/gems/globalize-b22845506598/lib/globalize/active_record/instance_methods.rb:169)

Fixes #653