### PR TITLE
jruby test CI fix

### DIFF
--- a/gemfiles/Gemfile.rails-4.2.rb
+++ b/gemfiles/Gemfile.rails-4.2.rb
@@ -16,14 +16,14 @@ end
 
 platforms :jruby do
   if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-    gem 'activerecord-jdbcsqlite3-adapter'
+    gem 'activerecord-jdbcsqlite3-adapter', '~> 1'
   end
 
   if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
-    gem 'activerecord-jdbcmysql-adapter'
+    gem 'activerecord-jdbcmysql-adapter', '~> 1'
   end
 
   if !ENV['TRAVIS'] || %w(postgres postgresql).include?(ENV['DB'])
-    gem 'activerecord-jdbcpostgresql-adapter'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1'
   end
 end


### PR DESCRIPTION
jruby activerecord gem support rails 4.2 only during version 1.x only.
So we should freeze version.

When we merge this PR and https://github.com/globalize/globalize/pull/652 and https://github.com/globalize/globalize/pull/651 .
CI will pass.