### PR TITLE
Fix: the attribute definition requires an active record cast type arg

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -97,8 +97,8 @@ module Globalize
         end
       end
 
-      def define_translated_attr_accessor(name)
-        attribute(name)
+      def define_translated_attr_accessor(name, cast_type = ::ActiveRecord::Type::String.new)
+        attribute(name, cast_type)
         define_translated_attr_reader(name)
         define_translated_attr_writer(name)
       end


### PR DESCRIPTION
Related to: https://github.com/globalize/globalize/commit/e946e639