### PR TITLE
Fix: Insert translation only when translation has changed  Reverts#341

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -99,11 +99,11 @@ module Globalize
                                 :foreign_key => options[:foreign_key],
                                 :dependent   => :destroy,
                                 :extend      => HasManyExtensions,
-                                :autosave    => true,
+                                :autosave    => false,
                                 :inverse_of  => :globalized_model
 
-        before_create :save_translations!
-        before_update :save_translations!
+        after_create :save_translations!
+        after_update :save_translations!
       end
     end
 

--- a/lib/globalize/active_record/adapter.rb
+++ b/lib/globalize/active_record/adapter.rb
@@ -43,6 +43,9 @@ module Globalize
             value = value.val if value.is_a?(Arel::Nodes::Casted)
             translation[name] = value
           end
+
+          ensure_foreign_key_for(translation)
+          translation.save!
         end
 
         reset
@@ -53,6 +56,12 @@ module Globalize
       end
 
       protected
+
+      # Sometimes the translation is initialised before a foreign key can be set.
+      def ensure_foreign_key_for(translation)
+        # AR >= 4.1 reflections renamed to _reflections
+        translation[translation.class.reflections.stringify_keys["globalized_model"].foreign_key] = record.id
+      end
 
       def type_cast(name, value)
         return value.presence unless column = column_for_attribute(name)

--- a/test/globalize_test.rb
+++ b/test/globalize_test.rb
@@ -105,6 +105,13 @@ class GlobalizeTest < MiniTest::Spec
         assert_translated post, :en, :title, 'title'
         assert_translated post, :de, :title, 'Titel'
       end
+
+      it "does not add tralations if no words changed" do
+        product = with_locale(:en) { Product.create(:name => 'name') }
+        with_locale(:de) { product.update_attributes(:updated_at => Time.now) }
+
+        assert_equal 1, product.reload.translations.size
+      end
     end
 
     describe '#write_attribute' do


### PR DESCRIPTION
I would expect that if I don't change any translatable words that no translations will be inserted into the database.  This was the case in version 5.0.1, changed in https://github.com/globalize/globalize/pull/341 for the 5.1.0 realease.  

To give an example of why this is a problem here is our specific use case:
In our application, we have email templates.  We have a set of default templates, and each customer may override the default templates with their own custom version.  The 5.1.0 behavior causes an empty translation record/email to be saved and then we would send out a blank email rather than the default. 

I think if this were merged with https://github.com/globalize/globalize/pull/656  and https://github.com/globalize/globalize/pull/668  then there would only be one failing test as a result of https://github.com/globalize/globalize/commit/e946e63983d42c9ff49b39b13ffcc3ad45626dd3