### PR TITLE
Fix: wrong number of arguments for ActiveRecord 'attribute' method

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -98,7 +98,7 @@ module Globalize
       end
 
       def define_translated_attr_accessor(name)
-        attribute(name)
+        attribute(name, ::ActiveRecord::Type::Value.new)
         define_translated_attr_reader(name)
         define_translated_attr_writer(name)
       end


### PR DESCRIPTION
When I setup Spree gem In Rails v5.0.6 I get the error
/home/intro/.rvm/gems/ruby-2.5.0/gems/activerecord-5.0.6/lib/active_record/attributes.rb:194:in 'attribute': wrong number of arguments (given 1, expected 2) (ArgumentError)
  from /home/intro/.rvm/gems/ruby-2.5.0/bundler/gems/globalize-d74687ff7b31/lib/globalize/active_record/class_methods.rb:101:in `define_translated_attr_accessor'

It happened because in Rails 5.0.6 ActiveRecord class method 'attribute' have not default value for 'cast_type' parameters:
  https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/attributes.rb#L194
In next versions of Rails it fixed and default value 'Type::Value.new'
  https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/attributes.rb#L194