### PR TITLE
_reset_attribute bugfix

### DIFF
--- a/lib/globalize/active_record/adapter_dirty.rb
+++ b/lib/globalize/active_record/adapter_dirty.rb
@@ -42,7 +42,7 @@ module Globalize
 
       def _reset_attribute name
         record.send("#{name}=", record.changed_attributes[name])
-        record.original_changed_attributes.except!(name)
+        record.clear_attribute_changes([name])
       end
 
       def reset


### PR DESCRIPTION
ActiveRecord saved changes data to changed_attributes and *AttributeMutationTracker* object.
But `_reset_attribute` method remove changes data from `changed_attributes` only.
So changed data is broken and test failed.

We use attribute_will_change metod but this method save changed data to mutation object by `force_change` method.
https://github.com/globalize/globalize/blob/1ef2fb09308c72027781f37f7e142856fe094049/lib/globalize/active_record/adapter_dirty.rb#L20
https://github.com/rails/rails/blob/v5.2.0.rc2/activemodel/lib/active_model/dirty.rb#L321

But we `_reset_attribute` metod remove changes data from @changed_attributes only.
https://github.com/globalize/globalize/blob/1ef2fb09308c72027781f37f7e142856fe094049/lib/globalize/active_record/adapter_dirty.rb#L45

So on this line `post.changes` return bug data.
https://github.com/globalize/globalize/blob/8615072907c02664b5b0a4d204db6daa782bfc07/test/globalize/dirty_tracking_test.rb#L41

We should use `clear_attribute_changes` method to remove changes.
This method remove changed from @changed_attributes and mutation object.