### PR TITLE
Support array as an argument of order

### DIFF
--- a/lib/globalize/active_record/query_methods.rb
+++ b/lib/globalize/active_record/query_methods.rb
@@ -110,6 +110,8 @@ module Globalize
           order(ordering).order_values
         when Symbol
           parse_translated_order({ opts => :asc })
+        when Array
+          parse_translated_order(Hash[opts.collect { |opt| [opt, :asc] } ])
         else # failsafe returns nothing
           nil
         end

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -205,6 +205,17 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
             end
           end
 
+          it 'returns record in order, columns in an array' do
+            @order = Post.where(title: 'title').order([:title, :content])
+
+            case Globalize::Test::Database.driver
+            when 'mysql'
+              assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
+            else
+              assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
+            end
+          end
+
           it 'returns record in order, leaving string untouched' do
             @order = Post.where(:title => 'title').order('title ASC')
             assert_equal ['title ASC'], @order.order_values


### PR DESCRIPTION
So it's possible to use translations in things like `Post.order([:title, :content])`