### PR TITLE
Bump rails dependency versions to '< 5.3'

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'activerecord', '>= 4.2', '< 5.2'
-  s.add_dependency 'activemodel', '>= 4.2', '< 5.2'
+  s.add_dependency 'activerecord', '>= 4.2', '< 5.3'
+  s.add_dependency 'activemodel', '>= 4.2', '< 5.3'
   s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'database_cleaner'


### PR DESCRIPTION
Ref #676 #612 .
Need update gemspec for Rails 5.2.