### PR TITLE
Run tests against MySQL by fixing mysql2 gem version

### DIFF
--- a/gemfiles/.gemfile.database-config.rb
+++ b/gemfiles/.gemfile.database-config.rb
@@ -5,7 +5,7 @@ end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'
   group :mysql do
-    gem 'mysql2', platforms: [:ruby, :rbx]
+    gem 'mysql2', '< 0.5', platforms: [:ruby, :rbx]
   end
 end
 


### PR DESCRIPTION
Hi there,

I specified the mysql2 gem version on the Gemfile for test environment.
This will fix failures about running tests against MySQL on Travis CI.
Could you review this?

Thanks,