### PR TITLE
Update changelog to reflect 5.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Globalize Changelog
 
-## 5.1.0 (unreleased)
+## 5.1.0 (2018-01-15)
 
 * Replaced `after_` callbacks with `before_` callbacks and set `autosave: true` by default. [#341](https://github.com/globalize/globalize/pull/341) by [Andrew Volozhanin](https://github.com/scarfacedeb)
 * Add [RequestStore](https://github.com/steveklabnik/request_store) to make Globalize thread-safe again [#420](https://github.com/globalize/globalize/pull/420)


### PR DESCRIPTION
5.1.0 was released last January in https://github.com/globalize/globalize/commit/a5ba7723f23f1cf611e0d94f8a3e75fed51baa66