### PR TITLE
Removes class translation defined without namespacing

### DIFF
--- a/test/data/models/translation.rb
+++ b/test/data/models/translation.rb
@@ -1,3 +1,0 @@
-# this little innocent class here makes 0.0.9 test fail
-class Translation < ActiveRecord::Base
-end


### PR DESCRIPTION
Addresses: https://github.com/globalize/globalize/issues/695

The class being removed was introduced here: https://github.com/globalize/globalize/pull/12
To solve this issue https://github.com/globalize/globalize/issues/10 

However, removing it doesn't seem to be causing any specs to fail, so either the test being referenced has been removed or this class being defined is no longer required. 

One way or another, having this definition is not a good idea, as it generates many potential conflicts making integration with existing apps more complex.


Before this change calling on a console:
::Translation
=> Results on a defined table
After
::Translation
=> Undefined constant

However, ModelName::Translation, still loads the right table