### PR TITLE
Add sqlite3 gem as development dependency

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
`sqlite3` is used in tests but not included in the gem list, so `rake test` was raising an error if it wasn't installed in the system.