### PR TITLE
Add support for translated attributes to other QueryMethods and Calculations

### DIFF
--- a/lib/globalize/active_record.rb
+++ b/lib/globalize/active_record.rb
@@ -1,14 +1,14 @@
 module Globalize
   module ActiveRecord
-    autoload :ActMacro,        'globalize/active_record/act_macro'
-    autoload :Adapter,         'globalize/active_record/adapter'
-    autoload :AdapterDirty,    'globalize/active_record/adapter_dirty'
-    autoload :Attributes,      'globalize/active_record/attributes'
-    autoload :ClassMethods,    'globalize/active_record/class_methods'
-    autoload :Exceptions,      'globalize/active_record/exceptions'
-    autoload :InstanceMethods, 'globalize/active_record/instance_methods'
-    autoload :Migration,       'globalize/active_record/migration'
-    autoload :Translation,     'globalize/active_record/translation'
-    autoload :QueryMethods,    'globalize/active_record/query_methods'
+    autoload :ActMacro,                     'globalize/active_record/act_macro'
+    autoload :Adapter,                      'globalize/active_record/adapter'
+    autoload :AdapterDirty,                 'globalize/active_record/adapter_dirty'
+    autoload :Attributes,                   'globalize/active_record/attributes'
+    autoload :ClassMethods,                 'globalize/active_record/class_methods'
+    autoload :Exceptions,                   'globalize/active_record/exceptions'
+    autoload :InstanceMethods,              'globalize/active_record/instance_methods'
+    autoload :Migration,                    'globalize/active_record/migration'
+    autoload :Translation,                  'globalize/active_record/translation'
+    autoload :TranslatedAttributesQuery,    'globalize/active_record/translated_attributes_query'
   end
 end

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -76,10 +76,10 @@ module Globalize
       private
 
       # Override the default relation method in order to return a subclass
-      # of ActiveRecord::Relation with custom finder methods for translated
-      # attributes.
+      # of ActiveRecord::Relation with custom finder and calculation methods
+      # for translated attributes.
       def relation
-        super.extending!(QueryMethods)
+        super.extending!(TranslatedAttributesQuery)
       end
 
       protected

--- a/lib/globalize/active_record/translated_attributes_query.rb
+++ b/lib/globalize/active_record/translated_attributes_query.rb
@@ -1,6 +1,6 @@
 module Globalize
   module ActiveRecord
-    module QueryMethods
+    module TranslatedAttributesQuery
       class WhereChain < ::ActiveRecord::QueryMethods::WhereChain
         def not(opts, *rest)
           if parsed = @scope.clone.parse_translated_conditions(opts)
@@ -21,8 +21,40 @@ module Globalize
         end
       end
 
+      def having(opts, *rest)
+        if parsed = parse_translated_conditions(opts)
+          join_translations(super(parsed, *rest))
+        else
+          super
+        end
+      end
+
       def order(opts, *rest)
         if respond_to?(:translated_attribute_names) && parsed = parse_translated_order(opts)
+          join_translations super(parsed)
+        else
+          super
+        end
+      end
+
+      def reorder(opts, *rest)
+        if respond_to?(:translated_attribute_names) && parsed = parse_translated_order(opts)
+          join_translations super(parsed)
+        else
+          super
+        end
+      end
+
+      def group(*columns)
+        if respond_to?(:translated_attribute_names) && parsed = parse_translated_columns(columns)
+          join_translations super(parsed)
+        else
+          super
+        end
+      end
+
+      def select(*columns)
+        if respond_to?(:translated_attribute_names) && parsed = parse_translated_columns(columns)
           join_translations super(parsed)
         else
           super
@@ -32,6 +64,24 @@ module Globalize
       def exists?(conditions = :none)
         if parsed = parse_translated_conditions(conditions)
           with_translations_in_fallbacks.exists?(parsed)
+        else
+          super
+        end
+      end
+
+      def calculate(*args)
+        column_name = args[1]
+        if respond_to?(:translated_attribute_names) && translated_column?(column_name)
+          args[1] = translated_column_name(column_name)
+          join_translations.calculate(*args)
+        else
+          super
+        end
+      end
+
+      def pluck(*column_names)
+        if respond_to?(:translated_attribute_names) && parsed = parse_translated_columns(column_names)
+          join_translations.pluck(*parsed)
         else
           super
         end
@@ -114,6 +164,12 @@ module Globalize
           parse_translated_order(Hash[opts.collect { |opt| [opt, :asc] } ])
         else # failsafe returns nothing
           nil
+        end
+      end
+
+      def parse_translated_columns(columns)
+        if columns.is_a?(Array) && (columns.flatten & translated_attribute_names).present?
+          columns.flatten.map { |column| translated_column?(column) ? translated_column_name(column) : column }
         end
       end
 

--- a/test/globalize/translated_attributes_query_test.rb
+++ b/test/globalize/translated_attributes_query_test.rb
@@ -2,63 +2,260 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class TranslatedAttributesQueryTest < MiniTest::Spec
-  describe '.where' do
+  def self.it_supports_translated_conditions(method)
     it 'finds records with matching attribute value in translations table' do
       post = Post.create(:title => 'title 1')
       Post.create(:title => 'title 2')
-      assert_equal [post], Post.where(:title => 'title 1').load
+      assert_equal [post], Post.group(:id, :title).send(method, :title => 'title 1').load
     end
 
     it 'handles string-valued attributes' do
       post = Post.create(:title => 'title 1')
       Post.create(:title => 'title 2')
-      assert_equal [post], Post.where('title' => 'title 1').load
+      assert_equal [post], Post.group(:id, :title).send(method, 'title' => 'title 1').load
     end
 
     it 'returns translations in this locale by default' do
       Globalize.with_locale(:ja) { Post.create(:title => 'タイトル') }
-      assert Post.where(:title => 'タイトル').empty?
+      assert Post.group(:id, :title).send(method, :title => 'タイトル').empty?
     end
 
     it 'returns chainable relation' do
       user = User.create(:email => 'foo@example.com', :name => 'foo')
       User.create(:email => 'bar@example.com', :name => 'foo')
       User.create(:email => 'foo@example.com', :name => 'baz')
-      assert_equal [user], User.where(:name => 'foo').where(:email => 'foo@example.com').load
+      assert_equal [user], User.group(:id, :name, :email).send(method, :name => 'foo').send(method, :email => 'foo@example.com').load
     end
 
     it 'parses translated attributes in chained relations' do
       user = User.create(:email => 'foo@example.com', :name => 'foo')
       User.create(:email => 'bar@example.com', :name => 'foo')
       User.create(:email => 'foo@example.com', :name => 'baz')
-      assert_equal [user], User.all.where(:email => 'foo@example.com').where(:name => 'foo').load
+      assert_equal [user], User.all.group(:id, :email, :name).send(method, :email => 'foo@example.com').send(method, :name => 'foo').load
     end
 
     it 'does not join translations table if query contains no translated attributes' do
-      assert_equal User.where(:name => 'foo').joins_values, [:translations]
-      assert_equal [], User.where(:email => 'foo@example.com').joins_values
+      assert_equal User.group(:id, :email).send(method, :name => 'foo').joins_values, [:translations]
+      assert_equal [], User.group(:id, :email).send(method, :email => 'foo@example.com').joins_values
     end
 
     it 'does not join translation table if already joined with with_translations' do
       user = Globalize.with_locale(:ja) { User.create(:email => 'foo@example.com', :name => 'foo') }
-      assert_equal [user], User.with_translations('ja').where(:name => 'foo').to_a
+      assert_equal [user], User.with_translations('ja').group(:id, :name).send(method, :name => 'foo').to_a
     end
+
+    it 'can be called with multiple arguments' do
+      user = User.create(:email => 'foo@example.com', :name => 'foo')
+      assert_equal user, User.group(:id, :email).send(method, "email = :email", { :email => 'foo@example.com' }).first
+    end
+
+    it 'duplicates arguments before modifying them' do
+      User.group(:id, :name).send(method, args = { :name => 'foo' })
+      assert_equal args, { :name => 'foo' }
+    end
+  end
+
+  def self.it_supports_translated_order(method)
+    describe 'returns record in order' do
+      describe 'for translated columns' do
+        it 'returns record in order, column as symbol' do
+          @order = Post.where(:title => 'title').send(method, :title)
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, column and direction as hash' do
+          @order = Post.where(:title => 'title').send(method, title: :desc)
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `post_translations`.`title` DESC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, columns in an array' do
+          @order = Post.where(title: 'title').send(method, [:title, :content])
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, leaving string untouched' do
+          @order = Post.where(:title => 'title').send(method, 'title ASC')
+          assert_equal ['title ASC'], @order.order_values
+        end
+
+        it 'generates a working query' do
+          sql = Post.send(method, :title).to_sql
+          assert Post.connection.execute(sql)
+        end
+
+        it 'returns relation that includes translated attribute' do
+          @order = Post.send(method, :title)
+          assert_equal [:translations], @order.joins_values
+        end
+      end
+
+      describe 'for non-translated columns' do
+        it 'returns record in order, column as symbol' do
+          @order = Post.where(:title => 'title').send(method, :id)
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `posts`.`id` ASC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "posts"."id" ASC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, column and direction as hash' do
+          @order = Post.where(:title => 'title').send(method, id: :desc)
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `posts`.`id` DESC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "posts"."id" DESC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, leaving string untouched' do
+          @order = Post.where(:title => 'title').send(method, 'id ASC')
+          assert_equal ['id ASC'], @order.order_values
+        end
+
+        it 'generates a working query' do
+          sql = Post.send(method, :id).to_sql
+          assert Post.connection.execute(sql)
+        end
+
+        it 'returns relation that does not include a translated attribute' do
+          @order = Post.send(method, :id)
+          assert_equal [], @order.joins_values
+        end
+      end
+
+      describe 'for mixed columns' do
+        it 'returns record in order, column and direction as hash' do
+          @order = Post.where(:title => 'title').send(method, title: :desc, id: :asc)
+
+          case Globalize::Test::Database.driver
+          when 'mysql'
+            assert_match(/ORDER BY `post_translations`.`title` DESC/, @order.to_sql)
+            assert_match(/`id` ASC/, @order.to_sql)
+          else
+            assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
+            assert_match(/"id" ASC/, @order.to_sql)
+          end
+        end
+
+        it 'returns record in order, leaving string untouched' do
+          @order = Post.where(:title => 'title').send(method, 'title ASC, id DESC')
+          assert_equal ['title ASC, id DESC'], @order.order_values
+        end
+
+        it 'generates a working query' do
+          sql = Post.send(method, :title, :id).to_sql
+          assert Post.connection.execute(sql)
+        end
+
+        it 'returns relation that includes translated attribute' do
+          @order = Post.send(method, :title, :id)
+          assert_equal [:translations], @order.joins_values
+        end
+      end
+    end
+  end
+
+  def self.it_supports_translated_columns(method)
+    describe 'for translated columns' do
+      it 'returns only selected attributes' do
+        @rel = Post.send(method, :title)
+        assert_match(/post_translations.title/, @rel.to_sql)
+      end
+
+      it 'generates a working query' do
+        rel = Post.send(method, :title)
+        rel = rel.select(:title) if method == :group
+        assert Post.connection.execute(rel.to_sql)
+      end
+
+      it 'returns relation that includes translated attribute' do
+        @rel = Post.send(method, :title)
+        assert_equal [:translations], @rel.joins_values
+      end
+    end
+
+    describe 'for non-translated columns' do
+      it 'returns only selected attributes' do
+        @rel = Post.send(method, :id)
+
+        case Globalize::Test::Database.driver
+        when 'mysql'
+          assert_match(/`posts`.`id`/, @rel.to_sql)
+        else
+          assert_match(/"posts"."id"/, @rel.to_sql)
+        end
+      end
+
+      it 'generates a working query' do
+        sql = Post.send(method, :id).to_sql
+        assert Post.connection.execute(sql)
+      end
+
+      it 'returns relation that does not include a translated attribute' do
+        @rel = Post.send(method, :id)
+        assert_equal [], @rel.joins_values
+      end
+    end
+
+    describe 'for mixed columns' do
+      it 'returns only selected attributes' do
+        @rel = Post.send(method, :title, :id)
+
+        case Globalize::Test::Database.driver
+        when 'mysql'
+          assert_match(/post_translations.title, `posts`.`id`/, @rel.to_sql)
+        else
+          assert_match(/post_translations.title, "posts"."id"/, @rel.to_sql)
+        end
+      end
+
+      it 'generates a working query' do
+        sql = Post.send(method, :title, :id).to_sql
+        assert Post.connection.execute(sql)
+      end
+
+      it 'returns relation that includes translated attribute' do
+        @rel = Post.send(method, :title, :id)
+        assert_equal [:translations], @rel.joins_values
+      end
+    end
+  end
+
+  describe '.where' do
+    it_supports_translated_conditions(:where)
 
     it 'can be called with no argument' do
       user = User.create(:email => 'foo@example.com', :name => 'foo')
       assert_equal [], User.where.not(:email => 'foo@example.com').load
       assert_equal [user], User.where.not(:email => 'bar@example.com').load
     end
+  end
 
-    it 'can be called with multiple arguments' do
-      user = User.create(:email => 'foo@example.com', :name => 'foo')
-      assert_equal user, User.where("email = :email", { :email => 'foo@example.com' }).first
-    end
-
-    it 'duplicates arguments before modifying them' do
-      User.where(args = { :name => 'foo' })
-      assert_equal args, { :name => 'foo' }
-    end
+  describe '.having' do
+    it_supports_translated_conditions(:having)
   end
 
   describe '.find_by' do
@@ -179,126 +376,72 @@ class TranslatedAttributesQueryTest < MiniTest::Spec
         assert_equal 2, @take.size
       end
     end
+  end
 
-    describe '.order' do
-      describe 'returns record in order' do
-        describe 'for translated columns' do
-          it 'returns record in order, column as symbol' do
-            @order = Post.where(:title => 'title').order(:title)
+  describe '.order' do
+    it_supports_translated_order(:order)
+  end
 
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
-            end
-          end
+  describe '.reorder' do
+    it_supports_translated_order(:reorder)
+  end
 
-          it 'returns record in order, column and direction as hash' do
-            @order = Post.where(:title => 'title').order(title: :desc)
+  describe '.select' do
+    it_supports_translated_columns(:select)
+  end
 
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `post_translations`.`title` DESC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
-            end
-          end
+  describe '.group' do
+    it_supports_translated_columns(:group)
+  end
 
-          it 'returns record in order, columns in an array' do
-            @order = Post.where(title: 'title').order([:title, :content])
+  describe 'calculations' do
+    before do
+      @posts = [
+        Post.create(:id => 1, :title => 'title1'),
+        Post.create(:id => 2, :title => 'title2'),
+        Post.create(:id => 3, :title => 'title3') ]
+      Globalize.with_locale(:ja) do
+        @posts[0].update_attributes(:title => 'タイトル1')
+        @posts[1].update_attributes(:title => 'タイトル2')
+        @posts[2].update_attributes(:title => 'タイトル3')
+      end
+    end
 
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `post_translations`.`title` ASC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "post_translations"."title" ASC/, @order.to_sql)
-            end
-          end
-
-          it 'returns record in order, leaving string untouched' do
-            @order = Post.where(:title => 'title').order('title ASC')
-            assert_equal ['title ASC'], @order.order_values
-          end
-
-          it 'generates a working query' do
-            sql = Post.order(:title).to_sql
-            assert Post.connection.execute(sql)
-          end
-
-          it 'returns relation that includes translated attribute' do
-            @order = Post.order(:title)
-            assert_equal [:translations], @order.joins_values
-          end
+    describe '.pluck' do
+      it 'plucks translated columns' do
+        assert_equal ['title1', 'title2', 'title3'], Post.pluck(:title).sort
+        Globalize.with_locale(:ja) do
+          assert_equal ['タイトル1', 'タイトル2', 'タイトル3'], Post.pluck(:title).sort
         end
+      end
 
-        describe 'for non-translated columns' do
-          it 'returns record in order, column as symbol' do
-            @order = Post.where(:title => 'title').order(:id)
-
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `posts`.`id` ASC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "posts"."id" ASC/, @order.to_sql)
-            end
-          end
-
-          it 'returns record in order, column and direction as hash' do
-            @order = Post.where(:title => 'title').order(id: :desc)
-
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `posts`.`id` DESC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "posts"."id" DESC/, @order.to_sql)
-            end
-          end
-
-          it 'returns record in order, leaving string untouched' do
-            @order = Post.where(:title => 'title').order('id ASC')
-            assert_equal ['id ASC'], @order.order_values
-          end
-
-          it 'generates a working query' do
-            sql = Post.order(:id).to_sql
-            assert Post.connection.execute(sql)
-          end
-
-          it 'returns relation that does not include a translated attribute' do
-            @order = Post.order(:id)
-            assert_equal [], @order.joins_values
-          end
+      it 'plucks non-translated columns' do
+        assert_equal [1, 2, 3], Post.pluck(:id).sort
+        Globalize.with_locale(:ja) do
+          assert_equal [1, 2, 3], Post.pluck(:id).sort
         end
+      end
 
-        describe 'for mixed columns' do
-          it 'returns record in order, column and direction as hash' do
-            @order = Post.where(:title => 'title').order(title: :desc, id: :asc)
+      it 'plucks mixed columns' do
+        assert_equal [[1, 'title1'], [2, 'title2'], [3, 'title3']], Post.pluck(:id, :title).sort
+        Globalize.with_locale(:ja) do
+          assert_equal [[1, 'タイトル1'], [2, 'タイトル2'], [3, 'タイトル3']], Post.pluck(:id, :title).sort
+        end
+      end
+    end
 
-            case Globalize::Test::Database.driver
-            when 'mysql'
-              assert_match(/ORDER BY `post_translations`.`title` DESC/, @order.to_sql)
-              assert_match(/`id` ASC/, @order.to_sql)
-            else
-              assert_match(/ORDER BY "post_translations"."title" DESC/, @order.to_sql)
-              assert_match(/"id" ASC/, @order.to_sql)
-            end
-          end
+    describe '.calculate' do
+      it 'calculates on translated column' do
+        assert_equal 'title3', Post.calculate(:maximum, :title)
+        Globalize.with_locale(:ja) do
+          assert_equal 'タイトル3', Post.calculate(:maximum, :title)
+        end
+      end
 
-          it 'returns record in order, leaving string untouched' do
-            @order = Post.where(:title => 'title').order('title ASC, id DESC')
-            assert_equal ['title ASC, id DESC'], @order.order_values
-          end
-
-          it 'generates a working query' do
-            sql = Post.order(:title, :id).to_sql
-            assert Post.connection.execute(sql)
-          end
-
-          it 'returns relation that includes translated attribute' do
-            @order = Post.order(:title, :id)
-            assert_equal [:translations], @order.joins_values
-          end
+      it 'calculates on non-translated column' do
+        assert_equal 3, Post.calculate(:maximum, :id)
+        Globalize.with_locale(:ja) do
+          assert_equal 3, Post.calculate(:maximum, :id)
         end
       end
     end


### PR DESCRIPTION
Adds support to pass the name of translated attribute to various other
QueryMethods and Calculation methods such that Globalize joins the translations
and use the correct database table/column, similar as is done for `order` and
`where`.

Renames QueryMethods to TranslatedAttributesQuery since it also contains methods
not from the ActiveRecord::QueryMethods module (but e.g. from Calculations).
It's also more similar to the test's name now.

Fixes https://github.com/globalize/globalize/issues/700