### PR TITLE
Fix all failed tests

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -54,15 +54,18 @@ module Globalize
       end
 
       def read_attribute(attr_name, options = {}, &block)
-        @globalize_read_attribute_options = options
-        ret = super(attr_name, &block)
-        @globalize_read_attribute_options = {}
-        ret
+        name = if self.class.attribute_alias?(attr_name)
+                 self.class.attribute_alias(attr_name).to_s
+               else
+                 attr_name.to_s
+               end
+
+        name = self.class.primary_key if name == "id".freeze && self.class.primary_key
+
+        _read_attribute(name, options, &block)
       end
 
       def _read_attribute(attr_name, options = {}, &block)
-        options = @globalize_read_attribute_options.merge(options) if defined?(@globalize_read_attribute_options)
-
         translated_value = read_translated_attribute(attr_name, options, &block)
         translated_value.nil? ? super(attr_name, &block) : translated_value
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -234,7 +234,7 @@ module Globalize
         return nil unless translated?(name)
 
         value = globalize.fetch(options[:locale] || Globalize.locale, name)
-        return nil unless value
+        return nil if value.nil?
 
         block_given? ? yield(value) : value
       end

--- a/test/globalize/fallbacks_test.rb
+++ b/test/globalize/fallbacks_test.rb
@@ -241,6 +241,7 @@ class FallbacksTest < MiniTest::Spec
     it 'does not result in duplicated records' do
       I18n.fallbacks.clear
       I18n.fallbacks.map :en => [ :de, :fr ]
+      I18n.fallbacks.map :fr => [ :en ]
       I18n.locale = :en
       
       product = Product.create(:name => 'foooooooo')

--- a/test/globalize/fallbacks_test.rb
+++ b/test/globalize/fallbacks_test.rb
@@ -225,6 +225,7 @@ class FallbacksTest < MiniTest::Spec
     it 'does not use fallbacks' do
       I18n.fallbacks.clear
       I18n.fallbacks.map :en => [ :de ]
+      I18n.fallbacks.map :de => [ :en ]
       I18n.locale = :en
 
       user = User.create(:name => 'John', :email => 'mad@max.com')


### PR DESCRIPTION
We fixed all failed tests.

**read_attribute bugfix**
Newest Rails use `read_attribute` method and `_read_attribute` method.  
But globalize override `read_attribute` method only so we can't translate 😢 
We override `_read_attribute` method and use translated value.

This method will not be changed, so I am doing a hard copy

**fallback_test bugfix**
Newest I18n exclude default locale  
https://github.com/svenfuchs/i18n/pull/415

So we fix fallback setup data.