### PR TITLE
FIX: stop registering the attr for Rails 4.2

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -98,7 +98,6 @@ module Globalize
       end
 
       def define_translated_attr_accessor(name)
-        attribute(name, ::ActiveRecord::Type::Value.new)
         define_translated_attr_reader(name)
         define_translated_attr_writer(name)
       end
@@ -121,6 +120,7 @@ module Globalize
       end
 
       def define_translations_accessor(name)
+        attribute(name, ::ActiveRecord::Type::Value.new) if ::ActiveRecord::VERSION::STRING >= "5.0"
         define_translations_reader(name)
         define_translations_writer(name)
       end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -5,11 +5,11 @@ class AttributesTest < MiniTest::Spec
 
   describe 'translated attribute reader' do
     it 'is defined for translated attributes' do
-      if ::ActiveRecord::VERSION::STRING < "5.0"
-        assert_equal Post.new.respond_to?(:title), false
-      else
-        assert_equal Post.new.respond_to?(:title), true
-      end
+      assert Post.new.respond_to?(:title)
+    end
+
+    it 'Post#columns does not include translated attributes' do
+      assert (Post.column_names.map(&:to_sym) & Post.translated_attribute_names.map(&:to_sym)).empty?
     end
 
     it 'returns the correct translation for a saved record after locale switching' do


### PR DESCRIPTION
## Rails Version

4.2.10

## Example 

`Post.includes(:attachments).where(attachments: {id: 123})`

Running the query above in the test suite will raise an exception because `ActiveRecord::Relation#include` relies on `.columns` to help build queries.

## Problem
ActiveRecord uses a model's  `.columns` method to help build queries. For example, `Post.columns` should not include `Post.translated_attribute_names`

