### PR TITLE
Update documentation for `config.i18n.fallbacks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ You can enable them by adding the next line to `config/application.rb` (or only
 `config/environments/production.rb` if you only want them in production)
 
 ```ruby
+# For version 1.1.0 and above of the `i18n` gem:
+config.i18n.fallbacks = [I18n.default_locale]
+# Below version 1.1.0 of the `i18n` gem:
 config.i18n.fallbacks = true
 ```
 


### PR DESCRIPTION
As suggested by the release documentation for version 1.1.0 of the `i18n` gem:

https://github.com/svenfuchs/i18n/releases/tag/v1.1.0