### PR TITLE
Add `create_source_columns` option for migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globalize Changelog
 
+## Unreleased
+
+* Add `create_source_columns` option for migrations. [#715](https://github.com/globalize/globalize/pull/715) by [IlyasValiullov](https://github.com/IlyasValiullov)
+
 ## 5.3.0 (2019-05-14)
 
 * Prevent 'SystemStackError: stack level too deep' error on attribute reset. [#722](https://github.com/globalize/globalize/pull/722) by [Reinier de Lange](https://github.com/moiristo)

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -62,6 +62,7 @@ module Globalize
         end
 
         def drop_translation_table!(options = {})
+          add_missing_columns if options[:create_source_columns]
           move_data_to_model_table if options[:migrate_data]
           drop_translations_index
           drop_translation_table
@@ -144,8 +145,6 @@ module Globalize
         end
 
         def move_data_to_model_table
-          add_missing_columns
-
           # Find all of the translated attributes for all records in the model.
           all_translated_attributes = model.all.collect{|m| m.attributes}
           all_translated_attributes.each do |translated_record|

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -178,6 +178,16 @@ class MigrationTest < MiniTest::Spec
       assert !Migrated.translation_class.index_exists_on?(:locale)
     end
 
+    it 'create source columns on drops the translations table' do
+      column_before = Migrated.columns.detect { |c| c.name == 'name' }
+
+      Migrated.create_translation_table!({:name => :string}, :remove_source_columns => true)
+      Migrated.drop_translation_table!(:create_source_columns => true)
+
+      column = Migrated.columns.detect { |c| c.name == 'name' }
+      assert_equal column_before.try(:type), column.try(:type)
+    end
+
     it 'cannot be called on non-translated models' do
       assert_raises NoMethodError do
         Blog.drop_translation_table!


### PR DESCRIPTION
If you use `migrate_date` option on `_create_translation_table_` method, then on roll back, `_drop_translation_table_ `fails because it try to create new columns that exist yet.

So I added create `create_source_columns` property (as reverse for `remove_source_columns`) to `_drop_translation_table_` method. 