### PR TITLE
Update gemspec to be compatible with Rails 6.0

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.rubyforge_project = '[none]'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'activerecord', '>= 4.2', '< 5.3'
-  s.add_dependency 'activemodel', '>= 4.2', '< 5.3'
+  s.add_dependency 'activerecord', '>= 4.2', '< 6.1'
+  s.add_dependency 'activemodel', '>= 4.2', '< 6.1'
   s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
This PR makes Globalize compatible with Rails 6.0, see https://github.com/globalize/globalize/issues/717