### PR TITLE
Pass the :limit option for the FK column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Gemfile*.lock
 .ruby-version
 test/globalize_test.log
 gemfiles/*.lock
+tmp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+services:
+  postgres:
+    image: postgres:11
+    volumes:
+      - ./tmp/postgres:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: ""
+  mysql:
+    image: mysql:8.0
+    volumes:
+      - ./tmp/mysql:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_USER: "root"
+      MYSQL_PASSWORD: ""
+      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/gemfiles/rails_4.2.10.gemfile
+++ b/gemfiles/rails_4.2.10.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "4.2.10"
 
 # Database Configuration
 if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-  gem 'sqlite3', platforms: [:ruby, :rbx]
+  gem 'sqlite3', '~> 1.3.6', platforms: [:ruby, :rbx]
 end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'

--- a/gemfiles/rails_5.1.6.gemfile
+++ b/gemfiles/rails_5.1.6.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "5.1.6"
 
 # Database Configuration
 if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-  gem 'sqlite3', platforms: [:ruby, :rbx]
+  gem 'sqlite3', '~> 1.3.6', platforms: [:ruby, :rbx]
 end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'

--- a/gemfiles/rails_5.2.1.gemfile
+++ b/gemfiles/rails_5.2.1.gemfile
@@ -7,7 +7,7 @@ gem "activerecord", "5.2.1"
 
 # Database Configuration
 if !ENV['TRAVIS'] || ENV['DB'] == 'sqlite3'
-  gem 'sqlite3', platforms: [:ruby, :rbx]
+  gem 'sqlite3', '~> 1.3.6', platforms: [:ruby, :rbx]
 end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'mysql'

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -78,7 +78,11 @@ module Globalize
 
         def create_translation_table
           connection.create_table(translations_table_name) do |t|
-            t.references table_name.sub(/^#{table_name_prefix}/, '').singularize, :null => false, :index => false, :type => column_type(model.primary_key).to_sym
+            t.references table_name.sub(/^#{table_name_prefix}/, '').singularize,
+                         :null => false,
+                         :index => false,
+                         :type => column_type(model.primary_key).try(:to_sym),
+                         :limit => model.columns.detect { |c| c.name == model.primary_key }.try(:limit)
             t.string :locale, :null => false
             t.timestamps :null => false
           end

--- a/test/data/models/migrated_bigint.rb
+++ b/test/data/models/migrated_bigint.rb
@@ -1,0 +1,4 @@
+class MigratedBigint < ActiveRecord::Base
+  self.primary_key = 'id'
+  translates :name
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -80,6 +80,13 @@ ActiveRecord::Schema.define do
     t.string :untranslated
   end
 
+  create_table :migrated_bigints, :force => true, :id => false do |t|
+    # supposed to create a bigint value for id
+    t.integer :id, :limit => 8, :primary_key => true
+    t.string :name
+    t.string :untranslated
+  end
+
   if Globalize::Test::Database.long_table_name_support?
     # Maximum length of a table name in MySQL and PostgreSQL are 64 characters
     create_table :migrated_with_mega_ultra_super_long_model_name_with_more_then_sixty_characters, :force => true do |t|

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -4,7 +4,7 @@ class MigrationTest < MiniTest::Spec
   include Globalize::ActiveRecord::Exceptions
 
   before(:each) do
-    reset_schema(Migrated, TwoAttributesMigrated)
+    reset_schema(Migrated, TwoAttributesMigrated, MigratedBigint)
     if Globalize::Test::Database.long_table_name_support?
       reset_schema(MigratedWithMegaUltraSuperLongModelNameWithMoreThenSixtyCharacters)
     end
@@ -14,7 +14,7 @@ class MigrationTest < MiniTest::Spec
   end
 
   after(:each) do
-    reset_schema(Migrated, TwoAttributesMigrated)
+    reset_schema(Migrated, TwoAttributesMigrated, MigratedBigint)
     if Globalize::Test::Database.long_table_name_support?
       reset_schema(MigratedWithMegaUltraSuperLongModelNameWithMoreThenSixtyCharacters)
     end
@@ -117,6 +117,11 @@ class MigrationTest < MiniTest::Spec
         # Was it restored? (also tests .untranslated_attributes)
         assert_equal 'Untranslated', untranslated.untranslated_attributes['name']
       end
+    end
+
+    it 'creates a proper types for FK ids' do
+      MigratedBigint.create_translation_table!(:name => :text)
+      assert_migration_table({}, MigratedBigint)
     end
   end
 
@@ -263,7 +268,7 @@ protected
     assert model.translation_class.index_exists_on?(index_field)
 
     assert_equal :string,   column_type(:locale, model)
-    assert_equal :integer,  column_type(index_field, model)
+    assert_equal model.type_for_attribute(model.primary_key), model.translation_class.type_for_attribute(index_field.to_s)
     assert_equal :datetime, column_type(:created_at, model)
     assert_equal :datetime, column_type(:updated_at, model)
 

--- a/test/support/database.rb
+++ b/test/support/database.rb
@@ -55,9 +55,9 @@ module Globalize
         db_config = config[driver]
         command = case driver
         when "mysql"
-          "mysql -u #{db_config['username']} -e 'create database #{db_config['database']} character set utf8 collate utf8_general_ci;' >/dev/null"
+          "mysql -u #{db_config['username']} --protocol tcp -e 'create database #{db_config['database']} character set utf8 collate utf8_general_ci;' >/dev/null"
         when "postgres", "postgresql"
-          "psql -c 'create database #{db_config['database']};' -U #{db_config['username']} >/dev/null"
+          "psql -c 'create database #{db_config['database']};' -U #{db_config['username']} -h localhost >/dev/null"
         end
 
         puts command
@@ -69,9 +69,9 @@ module Globalize
         db_config = config[driver]
         command = case driver
         when "mysql"
-          "mysql -u #{db_config['username']} -e 'drop database #{db_config["database"]};' >/dev/null"
+          "mysql -u #{db_config['username']} --protocol tcp -e 'drop database #{db_config["database"]};' >/dev/null"
         when "postgres", "postgresql"
-          "psql -c 'drop database #{db_config['database']};' -U #{db_config['username']} >/dev/null"
+          "psql -c 'drop database #{db_config['database']};' -U #{db_config['username']} -h localhost >/dev/null"
         end
 
         puts command

--- a/test/support/database.yml
+++ b/test/support/database.yml
@@ -1,6 +1,6 @@
 mysql:
   adapter: mysql2
-  host: localhost
+  host: 0.0.0.0
   port: 3306
   database: globalize_test
   username: root


### PR DESCRIPTION
## Problem

When the primary key of a translatable table is using bigint type it's not taken as the type of translations' foreign key using `column_descriptor.type`. At first I started considering using `column_descriptor.sql_type`, but there were some issues with it: it contains DB-specific value and seems to be a low-level of getting things done.
The final solution is to take `limit` of a PK and pass it to FK column creation, to make sure they match. It's more API-related way to set things up.

Related issue: #720 

## The PR contains:
- a solution for the problem with having a wrong type for FK of the translation table. In a nutshell, we always check the `sql_type` of a column and check if it contains `bigint` mention (`bigint` for PG and `bigint(8)` for MySQL), and decide what's the type of translation's FK based on that.
- tests, covering the case
- fixes in the testing methods (mysql and psql raw queries using CLI)
- a docker-compose file to make it easier to test MySQL and PG on a local machine
- a fix of sqlite3 version for tests, since it was always failing with the more flexible one