### PR TITLE
Prevent 'SystemStackError: stack level too deep' error on attribute reset

### DIFF
--- a/lib/globalize/active_record/adapter_dirty.rb
+++ b/lib/globalize/active_record/adapter_dirty.rb
@@ -42,7 +42,9 @@ module Globalize
       end
 
       def _reset_attribute name
-        record.send("#{name}=", record.changed_attributes[name])
+        original_value = record.changed_attributes[name]
+        record.send(:clear_attribute_changes, [name])
+        record.send("#{name}=", original_value)
         record.send(:clear_attribute_changes, [name])
       end
 

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -154,5 +154,12 @@ class DirtyTrackingTest < MiniTest::Spec
       post.title  = nil
       assert_equal ['content'], post.changed
     end
+
+    it 'only resets attributes once when nothing has changed' do
+      post = Post.create(:title => 'title', :content => 'content')
+      post.send(:set_attribute_was, 'content', 'content')
+      post.content = 'content'
+      assert post.save
+    end
   end
 end


### PR DESCRIPTION
Prevent 'SystemStackError: stack level too deep' error when resetting a dirty marked attribute that only has values that match the original values. Unchanged, the call loop below occurs for the added test. 

When the original value is reset, the current attribute is still marked dirty, therefore the original value is added over and over again to the old values (dirty) list.

```
/globalize/lib/globalize/active_record/instance_methods.rb:45:in `write_attribute'
/globalize/lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
/globalize/lib/globalize/active_record/adapter_dirty.rb:49:in `_reset_attribute'
/globalize/lib/globalize/active_record/adapter_dirty.rb:16:in `write'
/globalize/lib/globalize/active_record/instance_methods.rb:45:in `write_attribute'
/globalize/lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
/globalize/lib/globalize/active_record/adapter_dirty.rb:49:in `_reset_attribute'
/globalize/lib/globalize/active_record/adapter_dirty.rb:16:in `write'
/globalize/lib/globalize/active_record/instance_methods.rb:45:in `write_attribute'
/globalize/lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
/globalize/lib/globalize/active_record/adapter_dirty.rb:49:in `_reset_attribute'
/globalize/lib/globalize/active_record/adapter_dirty.rb:16:in `write'
/globalize/lib/globalize/active_record/instance_methods.rb:45:in `write_attribute'
/globalize/lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
/globalize/lib/globalize/active_record/adapter_dirty.rb:49:in `_reset_attribute'
/globalize/lib/globalize/active_record/adapter_dirty.rb:16:in `write'
/globalize/lib/globalize/active_record/instance_methods.rb:45:in `write_attribute'
/globalize/lib/globalize/active_record/class_methods.rb:96:in `block in define_translated_attr_writer'
/globalize/test/globalize/dirty_tracking_test.rb:161:in `block (2 levels) in <class:DirtyTrackingTest>'
```