### PR TITLE
Revert "Rescue ActiveRecord::NoDatabaseError..." to enable asset compilation in Docker

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -40,19 +40,15 @@ module Globalize
           self.translated_attribute_names << attr_name
         end
 
-        begin
-          if ::ActiveRecord::VERSION::STRING > "5.0" && table_exists? && translation_class.table_exists?
-            self.ignored_columns += translated_attribute_names.map(&:to_s)
-            reset_column_information
-          end
-        rescue ::ActiveRecord::NoDatabaseError
-          warn 'Unable to connect to a database. Globalize skipped ignoring columns of translated attributes.'
+        if ::ActiveRecord::VERSION::STRING > "5.0" && connected? && table_exists? && translation_class.table_exists?
+          self.ignored_columns += translated_attribute_names.map(&:to_s)
+          reset_column_information
         end
       end
 
       def check_columns!(attr_names)
         # If tables do not exist or Rails version is greater than 5, do not warn about conflicting columns
-        return unless ::ActiveRecord::VERSION::STRING < "5.0" && table_exists? && translation_class.table_exists?
+        return unless ::ActiveRecord::VERSION::STRING < "5.0" && connected? && table_exists? && translation_class.table_exists?
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
             ["You have defined one or more translated attributes with names that conflict with column(s) on the model table. ",
@@ -61,8 +57,6 @@ module Globalize
              "Attribute name(s): #{overlap.join(', ')}\n"].join
           )
         end
-      rescue ::ActiveRecord::NoDatabaseError
-        warn 'Unable to connect to a database. Globalize skipped checking attributes with conflicting column names.'
       end
 
       def apply_globalize_options(options)

--- a/test/globalize/bad_configuration_test.rb
+++ b/test/globalize/bad_configuration_test.rb
@@ -2,6 +2,12 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class BadConfigurationTest < MiniTest::Spec
+  before do
+    # We need to trigger a connection to AR to ensure the
+    # globalize hooks are called prior to these tests evaluating
+    ActiveRecord::Base.connection
+  end
+
   describe 'finders on data with bad configuration' do
     it 'works with find_by' do
       bad_configuration = BadConfiguration.create(:name => "foo")


### PR DESCRIPTION
This reverts commit 42b173f66e3a6a63e7908549aa5422881244596e to resolve (or partially work towards) https://github.com/globalize/globalize/issues/723.

I'm not sure if this is acceptable, as there seemed to be good motivations for the switch, but https://github.com/globalize/globalize/pull/602#issuecomment-472346040 (by the author of the patch this reverts) suggested there might have been something else going on. 

I figured I'd create this PR, just in case 😀.