### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.files        = Dir['{lib/**/*,[A-Z]*}']
   s.platform     = Gem::Platform::RUBY
   s.require_path = 'lib'
-  s.rubyforge_project = '[none]'
   s.required_ruby_version = '>= 2.4.6'
 
   s.add_dependency 'activerecord', '>= 4.2', '< 6.1'


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.