### PR TITLE
change migration to create fk between table translation and parent table

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -83,7 +83,8 @@ module Globalize
                          :null => false,
                          :index => false,
                          :type => column_type(model.primary_key).try(:to_sym),
-                         :limit => model.columns.detect { |c| c.name == model.primary_key }.try(:limit)
+                         :limit => model.columns.detect { |c| c.name == model.primary_key }.try(:limit),
+                         :foreign_key => true
             t.string :locale, :null => false
             t.timestamps :null => false
           end


### PR DESCRIPTION
Hello, I am doing a project to learn RubyOnRails and one of the requirements is to have multi-language models. Because of that, I analyzed some RubyGems and enjoyed the globalize, but I missed this FK between the tables to ensure data integrity. Perhaps my collaboration makes sense and is useful. Since already grateful for the attention and I'm really enjoying how to customize the world of gems.