### PR TITLE
Add Rails > 6.0 compatibility

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.4.6'
 
-  s.add_dependency 'activerecord', '>= 4.2', '< 6.1'
-  s.add_dependency 'activemodel', '>= 4.2', '< 6.1'
+  s.add_dependency 'activerecord', '>= 4.2', '< 7.0'
+  s.add_dependency 'activemodel', '>= 4.2', '< 7.0'
   s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Ref: https://github.com/globalize/globalize/issues/753#issuecomment-615241727

To test I've just upgraded my Gemfile with `gem 'rails', github: 'rails/rails'` and `gem 'globalize', github: 'sedubois/globalize', branch: 'rails-6-1'`, ran bundler, started the app and checked that some globalized models loaded successfully.