### PR TITLE
Ruby 2.7 save instance method deprecation warning fix

### DIFF
--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -158,7 +158,7 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      def save(*)
+      def save(**)
         result = Globalize.with_locale(translation.locale || I18n.default_locale) do
           without_fallbacks do
             super


### PR DESCRIPTION
See https://github.com/rails/rails/blob/57b4668c113b531f0b9a3e271b39aa19b686ab1d/activerecord/lib/active_record/suppressor.rb#L43