### PR TITLE
Fix the reference translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Add `create_source_columns` option for migrations. [#715](https://github.com/globalize/globalize/pull/715) by [IlyasValiullov](https://github.com/IlyasValiullov)
-* Autosave is now configurable, but defaults to false. [#736](https://github.com/globalize/globalize/pull/736) by [James Hart](https://github.com/hjhart) 
+* Autosave is now configurable, but defaults to false. [#736](https://github.com/globalize/globalize/pull/736) by [James Hart](https://github.com/hjhart)
+* Fix foreign keys translation. [#769](https://github.com/globalize/globalize/pull/769) by [Sergey Tokarenko](https://github.com/stokarenko)
 
 ## 5.3.0 (2019-05-14)
 

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -66,7 +66,7 @@ module Globalize
       end
 
       def _read_attribute(attr_name, options = {}, &block)
-        translated_value = read_translated_attribute(attr_name, options, &block)
+        translated_value = read_translated_attribute(attr_name, options)
         translated_value.nil? ? super(attr_name, &block) : translated_value
       end
 
@@ -236,10 +236,7 @@ module Globalize
         return nil unless options[:translated]
         return nil unless translated?(name)
 
-        value = globalize.fetch(options[:locale] || Globalize.locale, name)
-        return nil if value.nil?
-
-        block_given? ? yield(value) : value
+        globalize.fetch(options[:locale] || Globalize.locale, name)
       end
     end
   end

--- a/test/data/models/post.rb
+++ b/test/data/models/post.rb
@@ -1,8 +1,9 @@
 class Post < ActiveRecord::Base
-  translates :title, :content, :published, :published_at
+  translates :title, :content, :published, :published_at, :media_id
   validates_presence_of :title
   scope :with_some_title, proc { { :conditions => { :title => 'some_title' } } }
   accepts_nested_attributes_for :translations
   has_many :attachments
   has_many :translated_comments
+  belongs_to :media
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define do
 
   create_table :posts, :force => true do |t|
     t.references :blog
+    t.references :media
   end
 
   create_table :post_translations, :force => true do |t|
@@ -36,6 +37,7 @@ ActiveRecord::Schema.define do
     t.text       :content
     t.boolean    :published
     t.datetime   :published_at
+    t.integer    :media_id
   end
 
   create_table :products, :force => true do |t|

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define do
 
   create_table :posts, :force => true do |t|
     t.references :blog
-    t.references :media
   end
 
   create_table :post_translations, :force => true do |t|
@@ -37,7 +36,7 @@ ActiveRecord::Schema.define do
     t.text       :content
     t.boolean    :published
     t.datetime   :published_at
-    t.integer    :media_id
+    t.references :media
   end
 
   create_table :products, :force => true do |t|

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -140,6 +140,12 @@ class AttributesTest < MiniTest::Spec
       saved_locales = post.translations.map(&:locale)
       assert saved_locales.include? :it
     end
+
+    it 'translates the reference' do
+      media = Media.create!
+      post = Post.create!(title: 'title', media: media)
+      assert_equal media.id, post.media_id
+    end
   end
 
   describe '#attribute_names' do


### PR DESCRIPTION
It fixes [a little regression](https://github.com/globalize/globalize/pull/709/files#diff-d14f092167b54dd486cb43639c5be55de3a92bb741db0066c3415acad4429db3R242) coming in `v5.2`:

1) now we yield the translated value into the block passed to `_read_attribute`, but..
2) in terms of ActiveRecord [this block means the `missing_attribute` callback](https://github.com/rails/rails/blob/v6.0.3.4/activerecord/lib/active_record/associations/belongs_to_association.rb#L119), so it happen that..
3) `globalize` successfully translates, say, `media_id` to `5` and yields the value into `missing_attribute` callback, effectively..
4) raising pretty weird `ActiveModel::MissingAttributeError: missing attribute: 5` exception.

This only happen when we define the foreign reference as translated attribute (don't ask me why.. ;) )