### PR TITLE
Fix errors with Rails 6.1 and Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,19 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql, sqlite3 ]
-        gemfile: [ '6.1.0', '6.0.3.4', '5.2.4.4', '5.1.7', '4.2.11.3' ]
+        gemfile: [ '6.1.3.1', '6.0.3.6', '5.2.5', '5.1.7', '4.2.11.3' ]
         ruby: [ '2.7', '2.6', '2.5', '2.4' ]
         exclude:
           - ruby: '2.7'
-            gemfile: '5.2.4.4'
+            gemfile: '5.2.5'
           - ruby: '2.7'
             gemfile: '5.1.7'
           - ruby: '2.7'
             gemfile: '4.2.11.3'
           - ruby: '2.4'
-            gemfile: '6.1.0'
+            gemfile: '6.1.3.1'
           - ruby: '2.4'
-            gemfile: '6.0.3.4'
+            gemfile: '6.0.3.6'
       fail-fast: false
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,14 @@ jobs:
       matrix:
         database: [ mysql, postgresql, sqlite3 ]
         gemfile: [ '6.1.3.1', '6.0.3.6', '5.2.5', '5.1.7', '4.2.11.3' ]
-        ruby: [ '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
         exclude:
+          - ruby: '3.0'
+            gemfile: '5.2.5'
+          - ruby: '3.0'
+            gemfile: '5.1.7'
+          - ruby: '3.0'
+            gemfile: '4.2.11.3'
           - ruby: '2.7'
             gemfile: '5.2.5'
           - ruby: '2.7'

--- a/Appraisals
+++ b/Appraisals
@@ -3,9 +3,9 @@
 RAILS_VERSIONS = %w[
   4.2.11.3
   5.1.7
-  5.2.4.4
-  6.0.3.4
-  6.1.0
+  5.2.5
+  6.0.3.6
+  6.1.3.1
 ]
 
 RAILS_VERSIONS.each do |version|

--- a/Appraisals
+++ b/Appraisals
@@ -31,11 +31,6 @@ RAILS_VERSIONS.each do |version|
       end
     end
 
-    platforms :rbx do
-      gem "rubysl", "~> 2.0"
-      gem "rubinius-developer_tools"
-    end
-
     platforms :jruby do
       if !ENV['CI'] || ENV['DB'] == 'sqlite3'
         gem 'activerecord-jdbcsqlite3-adapter', '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,6 @@ end
 
 if !ENV['CI'] || %w(postgres postgresql).include?(ENV['DB'])
   group :postgres, :postgresql do
-    gem 'pg', '< 1.0', platforms: [:ruby, :rbx]
+    gem 'pg', platforms: [:ruby, :rbx]
   end
 end

--- a/gemfiles/rails_4.2.11.3.gemfile
+++ b/gemfiles/rails_4.2.11.3.gemfile
@@ -14,11 +14,6 @@ group :postgres, :postgresql do
   gem "pg", "< 1.0", platforms: [:ruby, :rbx]
 end
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1"
   gem "activerecord-jdbcmysql-adapter", "~> 1"

--- a/gemfiles/rails_5.1.7.gemfile
+++ b/gemfiles/rails_5.1.7.gemfile
@@ -14,11 +14,6 @@ group :postgres, :postgresql do
   gem "pg", "~> 1.1", platforms: [:ruby, :rbx]
 end
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1"
   gem "activerecord-jdbcmysql-adapter", "~> 1"

--- a/gemfiles/rails_5.2.5.gemfile
+++ b/gemfiles/rails_5.2.5.gemfile
@@ -14,11 +14,6 @@ group :postgres, :postgresql do
   gem "pg", "~> 1.1", platforms: [:ruby, :rbx]
 end
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1"
   gem "activerecord-jdbcmysql-adapter", "~> 1"

--- a/gemfiles/rails_5.2.5.gemfile
+++ b/gemfiles/rails_5.2.5.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.4", platforms: [:ruby, :rbx]
-gem "activemodel", "6.1.0"
-gem "activerecord", "6.1.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:ruby, :rbx]
+gem "activemodel", "5.2.5"
+gem "activerecord", "5.2.5"
 
 group :mysql do
   gem "mysql2", platforms: [:ruby, :rbx]

--- a/gemfiles/rails_6.0.3.6.gemfile
+++ b/gemfiles/rails_6.0.3.6.gemfile
@@ -14,11 +14,6 @@ group :postgres, :postgresql do
   gem "pg", "~> 1.1", platforms: [:ruby, :rbx]
 end
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1"
   gem "activerecord-jdbcmysql-adapter", "~> 1"

--- a/gemfiles/rails_6.0.3.6.gemfile
+++ b/gemfiles/rails_6.0.3.6.gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:ruby, :rbx]
-gem "activemodel", "5.2.4.4"
-gem "activerecord", "5.2.4.4"
+gem "sqlite3", "~> 1.4", platforms: [:ruby, :rbx]
+gem "activemodel", "6.0.3.6"
+gem "activerecord", "6.0.3.6"
 
 group :mysql do
   gem "mysql2", platforms: [:ruby, :rbx]

--- a/gemfiles/rails_6.1.3.1.gemfile
+++ b/gemfiles/rails_6.1.3.1.gemfile
@@ -3,8 +3,8 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: [:ruby, :rbx]
-gem "activemodel", "6.0.3.4"
-gem "activerecord", "6.0.3.4"
+gem "activemodel", "6.1.3.1"
+gem "activerecord", "6.1.3.1"
 
 group :mysql do
   gem "mysql2", platforms: [:ruby, :rbx]

--- a/gemfiles/rails_6.1.3.1.gemfile
+++ b/gemfiles/rails_6.1.3.1.gemfile
@@ -14,11 +14,6 @@ group :postgres, :postgresql do
   gem "pg", "~> 1.1", platforms: [:ruby, :rbx]
 end
 
-platforms :rbx do
-  gem "rubysl", "~> 2.0"
-  gem "rubinius-developer_tools"
-end
-
 platforms :jruby do
   gem "activerecord-jdbcsqlite3-adapter", "~> 1"
   gem "activerecord-jdbcmysql-adapter", "~> 1"

--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -11,6 +11,12 @@ module Globalize
   autoload :ActiveRecord, 'globalize/active_record'
   autoload :Interpolation,   'globalize/interpolation'
 
+  ACTIVE_RECORD_50 = Gem::Version.new('5.0.0')
+  ACTIVE_RECORD_51 = Gem::Version.new('5.1.0')
+  ACTIVE_RECORD_52 = Gem::Version.new('5.2.0')
+  ACTIVE_RECORD_60 = Gem::Version.new('6.0.0')
+  ACTIVE_RECORD_61 = Gem::Version.new('6.1.0')
+
   class << self
     def locale
       read_locale || I18n.locale
@@ -58,20 +64,28 @@ module Globalize
       RequestStore.store
     end
 
+    def rails_42?
+      ::ActiveRecord.version < ACTIVE_RECORD_50
+    end
+
+    def rails_5?
+      ::ActiveRecord.version >= ACTIVE_RECORD_50
+    end
+
     def rails_51?
-      ::ActiveRecord.version >= Gem::Version.new('5.1.0')
+      ::ActiveRecord.version >= ACTIVE_RECORD_51
     end
 
     def rails_52?
-      ::ActiveRecord.version >= Gem::Version.new('5.2.0')
+      ::ActiveRecord.version >= ACTIVE_RECORD_52
     end
 
     def rails_6?
-      ::ActiveRecord.version >= Gem::Version.new('6.0.0')
+      ::ActiveRecord.version >= ACTIVE_RECORD_60
     end
 
     def rails_61?
-      ::ActiveRecord.version >= Gem::Version.new('6.1.0')
+      ::ActiveRecord.version >= ACTIVE_RECORD_61
     end
 
   protected

--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -17,6 +17,9 @@ module Globalize
   ACTIVE_RECORD_60 = Gem::Version.new('6.0.0')
   ACTIVE_RECORD_61 = Gem::Version.new('6.1.0')
 
+  CURRENT_RUBY     = Gem::Version.new(RUBY_VERSION)
+  RUBY_VERSION_27  = Gem::Version.new('2.7.0')
+
   class << self
     def locale
       read_locale || I18n.locale
@@ -62,6 +65,10 @@ module Globalize
     # Thread-safe global storage
     def storage
       RequestStore.store
+    end
+
+    def ruby_27?
+      CURRENT_RUBY >= RUBY_VERSION_27
     end
 
     def rails_42?

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -41,7 +41,7 @@ module Globalize
         end
 
         begin
-          if ::ActiveRecord::VERSION::STRING > "5.0" && table_exists? && translation_class.table_exists?
+          if Globalize.rails_5? && table_exists? && translation_class.table_exists?
             self.ignored_columns += translated_attribute_names.map(&:to_s)
             reset_column_information
           end
@@ -52,7 +52,7 @@ module Globalize
 
       def check_columns!(attr_names)
         # If tables do not exist or Rails version is greater than 5, do not warn about conflicting columns
-        return unless ::ActiveRecord::VERSION::STRING < "5.0" && table_exists? && translation_class.table_exists?
+        return unless Globalize.rails_42? && table_exists? && translation_class.table_exists?
         if (overlap = attr_names.map(&:to_s) & column_names).present?
           ActiveSupport::Deprecation.warn(
             ["You have defined one or more translated attributes with names that conflict with column(s) on the model table. ",

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -3,7 +3,7 @@ module Globalize
     module ClassMethods
       delegate :translated_locales, :set_translations_table_name, :to => :translation_class
 
-      if ::ActiveRecord::VERSION::STRING < "5.0.0"
+      if Globalize.rails_42?
         def columns_hash
           super.except(*translated_attribute_names.map(&:to_s))
         end
@@ -120,7 +120,7 @@ module Globalize
       end
 
       def define_translations_accessor(name)
-        attribute(name, ::ActiveRecord::Type::Value.new) if ::ActiveRecord::VERSION::STRING >= "5.0"
+        attribute(name, ::ActiveRecord::Type::Value.new) if Globalize.rails_5?
         define_translations_reader(name)
         define_translations_writer(name)
       end

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -158,20 +158,21 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      if Globalize.rails_61?
-        # Rails 6.1 and later has removed positional arguments which were never used
-        def save(**)
-          result = Globalize.with_locale(translation.locale || I18n.default_locale) do
-            without_fallbacks do
-              super
+      if Globalize.ruby_27?
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def save(...)
+            result = Globalize.with_locale(translation.locale || I18n.default_locale) do
+              without_fallbacks do
+                super
+              end
             end
-          end
-          if result
-            globalize.clear_dirty
-          end
+            if result
+              globalize.clear_dirty
+            end
 
-          result
-        end
+            result
+          end
+        RUBY
       else
         def save(*)
           result = Globalize.with_locale(translation.locale || I18n.default_locale) do

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -158,17 +158,33 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      def save(*)
-        result = Globalize.with_locale(translation.locale || I18n.default_locale) do
-          without_fallbacks do
-            super
+      if Globalize.rails_61?
+        # Rails 6.1 and later has removed positional arguments which were never used
+        def save(**)
+          result = Globalize.with_locale(translation.locale || I18n.default_locale) do
+            without_fallbacks do
+              super
+            end
           end
-        end
-        if result
-          globalize.clear_dirty
-        end
+          if result
+            globalize.clear_dirty
+          end
 
-        result
+          result
+        end
+      else
+        def save(*)
+          result = Globalize.with_locale(translation.locale || I18n.default_locale) do
+            without_fallbacks do
+              super
+            end
+          end
+          if result
+            globalize.clear_dirty
+          end
+
+          result
+        end
       end
 
       def column_for_attribute name

--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -89,13 +89,27 @@ module Globalize
           end
         end
 
-        def add_translation_fields
-          connection.change_table(translations_table_name) do |t|
-            fields.each do |name, options|
-              if options.is_a? Hash
-                t.column name, options.delete(:type), options
-              else
-                t.column name, options
+        if Globalize.rails_6?
+          def add_translation_fields
+            connection.change_table(translations_table_name) do |t|
+              fields.each do |name, options|
+                if options.is_a? Hash
+                  t.column name, options.delete(:type), **options
+                else
+                  t.column name, options
+                end
+              end
+            end
+          end
+        else
+          def add_translation_fields
+            connection.change_table(translations_table_name) do |t|
+              fields.each do |name, options|
+                if options.is_a? Hash
+                  t.column name, options.delete(:type), options
+                else
+                  t.column name, options
+                end
               end
             end
           end

--- a/lib/globalize/active_record/translated_attributes_query.rb
+++ b/lib/globalize/active_record/translated_attributes_query.rb
@@ -99,7 +99,7 @@ module Globalize
         end
       end
 
-      if ::ActiveRecord::VERSION::STRING < "5.0.0"
+      if Globalize.rails_42?
         def where_values_hash(*args)
           return super unless respond_to?(:translations_table_name)
           equalities = respond_to?(:with_default_scope) ? with_default_scope.where_values : where_values

--- a/lib/patches/active_record/query_method.rb
+++ b/lib/patches/active_record/query_method.rb
@@ -1,3 +1,3 @@
-if ::ActiveRecord::VERSION::STRING < "5.0.0"
+if ::ActiveRecord.version < Gem::Version.new("5.0.0")
   require_relative 'rails4/query_method'
 end

--- a/lib/patches/active_record/rails6_1/uniqueness_validator.rb
+++ b/lib/patches/active_record/rails6_1/uniqueness_validator.rb
@@ -1,0 +1,45 @@
+module Globalize
+  module Validations
+    module UniquenessValidator
+      def validate_each(record, attribute, value)
+        klass = record.class
+        if klass.translates? && klass.translated?(attribute)
+          finder_class = klass.translation_class
+          relation = build_relation(finder_class, attribute, value).where(locale: Globalize.locale)
+          relation = relation.where.not(klass.reflect_on_association(:translations).foreign_key => record.send(:id)) if record.persisted?
+
+
+          translated_scopes = Array(options[:scope]) & klass.translated_attribute_names
+          untranslated_scopes = Array(options[:scope]) - translated_scopes
+
+          relation = relation.joins(:globalized_model) if untranslated_scopes.present?
+          untranslated_scopes.each do |scope_item|
+            scope_value = record.send(scope_item)
+            reflection = klass.reflect_on_association(scope_item)
+            if reflection
+              scope_value = record.send(reflection.foreign_key)
+              scope_item = reflection.foreign_key
+            end
+            relation = relation.where(find_finder_class_for(record).table_name => { scope_item => scope_value })
+          end
+
+          translated_scopes.each do |scope_item|
+            scope_value = record.send(scope_item)
+            relation = relation.where(scope_item => scope_value)
+          end
+          relation = relation.merge(options[:conditions]) if options[:conditions]
+
+          if relation.exists?
+            error_options = options.except(:case_sensitive, :scope, :conditions)
+            error_options[:value] = value
+            record.errors.add(attribute, :taken, **error_options)
+          end
+        else
+          super(record, attribute, value)
+        end
+      end
+    end
+  end
+end
+
+ActiveRecord::Validations::UniquenessValidator.prepend Globalize::Validations::UniquenessValidator

--- a/lib/patches/active_record/relation.rb
+++ b/lib/patches/active_record/relation.rb
@@ -1,9 +1,16 @@
-if ::ActiveRecord::VERSION::STRING >= "5.0.0"
+if ::ActiveRecord.version >= Gem::Version.new("5.0.0")
   module Globalize
     module Relation
       def where_values_hash(relation_table_name = table_name)
         return super unless respond_to?(:translations_table_name)
         super.merge(super(translations_table_name))
+      end
+
+      if ::ActiveRecord.version >= Gem::Version.new("6.1.3")
+        def scope_for_create
+          return super unless respond_to?(:translations_table_name)
+          super.merge(where_values_hash(translations_table_name))
+        end
       end
     end
   end

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,4 +1,4 @@
-if ::ActiveRecord::VERSION::STRING < "5.1.0"
+if ::ActiveRecord.version < Gem::Version.new("5.1.0")
   require_relative 'rails4/serialization'
 else
   require_relative 'rails5_1/serialization'

--- a/lib/patches/active_record/uniqueness_validator.rb
+++ b/lib/patches/active_record/uniqueness_validator.rb
@@ -2,6 +2,8 @@ if ::ActiveRecord.version < Gem::Version.new("5.0.0")
   require_relative 'rails4/uniqueness_validator'
 elsif ::ActiveRecord.version < Gem::Version.new("5.1.0")
   require_relative 'rails5/uniqueness_validator'
-else
+elsif ::ActiveRecord.version < Gem::Version.new("6.1.0")
   require_relative 'rails5_1/uniqueness_validator'
+else
+  require_relative 'rails6_1/uniqueness_validator'
 end

--- a/lib/patches/active_record/uniqueness_validator.rb
+++ b/lib/patches/active_record/uniqueness_validator.rb
@@ -1,6 +1,6 @@
-if ::ActiveRecord::VERSION::STRING < "5.0.0"
+if ::ActiveRecord.version < Gem::Version.new("5.0.0")
   require_relative 'rails4/uniqueness_validator'
-elsif ::ActiveRecord::VERSION::STRING < "5.1.0"
+elsif ::ActiveRecord.version < Gem::Version.new("5.1.0")
   require_relative 'rails5/uniqueness_validator'
 else
   require_relative 'rails5_1/uniqueness_validator'


### PR DESCRIPTION
Ruby 3.0 no longer expands option hashes to keyword arguments so where Rails has an explicit `**options` it now fails with an `ArgumentError`. This PR also fixes an issue with Rails 6.1.3 where we accidentally broke compatibility by changing how `scope_for_create` was built.