### PR TITLE
Track saved_changes for Rails 5.1 and above

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -58,7 +58,7 @@ module Globalize
       RequestStore.store
     end
 
-    def rails_5?
+    def rails_51?
       ::ActiveRecord.version >= Gem::Version.new('5.1.0')
     end
 

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -185,6 +185,18 @@ module Globalize
         changed_attributes.present? || translations.any?(&:changed?)
       end
 
+      if Globalize.rails_5?
+        def saved_changes
+          super.tap do |changes|
+            translation = translation_for(::Globalize.locale, false)
+            if translation
+              translation_changes = translation.saved_changes.select { |name| translated?(name) }
+              changes.merge!(translation_changes) if !translation_changes.empty?
+            end
+          end
+        end
+      end
+
       if Globalize.rails_6?
         def changed_attributes
           super.merge(globalize.changed_attributes(::Globalize.locale))

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -185,7 +185,7 @@ module Globalize
         changed_attributes.present? || translations.any?(&:changed?)
       end
 
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         def saved_changes
           super.tap do |changes|
             translation = translation_for(::Globalize.locale, false)

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -191,7 +191,7 @@ module Globalize
             translation = translation_for(::Globalize.locale, false)
             if translation
               translation_changes = translation.saved_changes.select { |name| translated?(name) }
-              changes.merge!(translation_changes) if !translation_changes.empty?
+              changes.merge!(translation_changes) if translation_changes.any?
             end
           end
         end

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -168,4 +168,30 @@ class DirtyTrackingTest < MiniTest::Spec
       assert post.save
     end
   end
+
+  describe '#saved_changes' do
+    it 'tracks saved changes in each locale' do
+      post = Post.create!(:title => 'title', :content => 'content')
+      assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
+
+      post.title = 'changed title'
+      post.save
+      assert_equal({ 'title' => ['title', 'changed title'] }, post.saved_changes)
+
+      I18n.locale = :de
+      assert_nil post.title
+
+      post.title = 'Titel'
+      post.save
+      assert_equal({ 'title' => [nil, 'Titel'] }, post.saved_changes)
+    end
+
+    it 'clears saved changes after reload' do
+      post = Post.create!(:title => 'title', :content => 'content')
+      assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
+
+      post.reload
+      assert_equal({}, post.saved_changes)
+    end
+  end
 end

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -106,7 +106,7 @@ class DirtyTrackingTest < MiniTest::Spec
 
       post.title = 'english title'
 
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ['title', 'content'], post.changed
       else
         assert_equal ['content', 'title'], post.changed
@@ -115,7 +115,7 @@ class DirtyTrackingTest < MiniTest::Spec
       I18n.locale = :de
       post.title  = nil
 
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ['title', 'content'], post.changed
       else
         assert_equal ['content', 'title'], post.changed
@@ -127,7 +127,7 @@ class DirtyTrackingTest < MiniTest::Spec
       assert_equal ['content'], post.changed
 
       post.title = 'english title'
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ['title', 'content'], post.changed
       else
         assert_equal ['content', 'title'], post.changed
@@ -136,7 +136,7 @@ class DirtyTrackingTest < MiniTest::Spec
       I18n.locale = :de
       post.title  = 'title de'
 
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ['title', 'content'], post.changed
       else
         assert_equal ['content', 'title'], post.changed
@@ -144,7 +144,7 @@ class DirtyTrackingTest < MiniTest::Spec
 
       I18n.locale = :en
       post.title  = nil
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ['title', 'content'], post.changed
       else
         assert_equal ['content', 'title'], post.changed
@@ -169,7 +169,7 @@ class DirtyTrackingTest < MiniTest::Spec
     end
   end
 
-  if Globalize.rails_5?
+  if Globalize.rails_51?
     describe '#saved_changes' do
       it 'tracks saved changes in each locale' do
         post = Post.create!(:title => 'title', :content => 'content')

--- a/test/globalize/dirty_tracking_test.rb
+++ b/test/globalize/dirty_tracking_test.rb
@@ -169,29 +169,31 @@ class DirtyTrackingTest < MiniTest::Spec
     end
   end
 
-  describe '#saved_changes' do
-    it 'tracks saved changes in each locale' do
-      post = Post.create!(:title => 'title', :content => 'content')
-      assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
+  if Globalize.rails_5?
+    describe '#saved_changes' do
+      it 'tracks saved changes in each locale' do
+        post = Post.create!(:title => 'title', :content => 'content')
+        assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
 
-      post.title = 'changed title'
-      post.save
-      assert_equal({ 'title' => ['title', 'changed title'] }, post.saved_changes)
+        post.title = 'changed title'
+        post.save
+        assert_equal({ 'title' => ['title', 'changed title'] }, post.saved_changes)
 
-      I18n.locale = :de
-      assert_nil post.title
+        I18n.locale = :de
+        assert_nil post.title
 
-      post.title = 'Titel'
-      post.save
-      assert_equal({ 'title' => [nil, 'Titel'] }, post.saved_changes)
-    end
+        post.title = 'Titel'
+        post.save
+        assert_equal({ 'title' => [nil, 'Titel'] }, post.saved_changes)
+      end
 
-    it 'clears saved changes after reload' do
-      post = Post.create!(:title => 'title', :content => 'content')
-      assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
+      it 'clears saved changes after reload' do
+        post = Post.create!(:title => 'title', :content => 'content')
+        assert_equal({ 'id' => [nil, post.id], 'title' => [nil, 'title'], 'content' => [nil, 'content'] }, post.saved_changes)
 
-      post.reload
-      assert_equal({}, post.saved_changes)
+        post.reload
+        assert_equal({}, post.saved_changes)
+      end
     end
   end
 end

--- a/test/globalize/joins_test.rb
+++ b/test/globalize/joins_test.rb
@@ -8,7 +8,7 @@ class JoinsTest < MiniTest::Spec
     it "returns translated attribute" do
       Post.create(title: "my title")
 
-      if Globalize.rails_5?
+      if Globalize.rails_51?
         assert_equal ["my title"], Post.includes(:translations).pluck("post_translations.title")
       else
         assert_equal ["my title"], Post.includes(:translations).pluck(:title)

--- a/test/globalize/migration_test.rb
+++ b/test/globalize/migration_test.rb
@@ -162,7 +162,7 @@ class MigrationTest < MiniTest::Spec
         assert_translated untranslated_record, :en, :name, 'Untranslated'
         assert_translated untranslated_record, :en, :body, 'Untranslated body'
 
-        if Globalize.rails_5?
+        if Globalize.rails_51?
           assert_nil model.columns.detect { |c| c.name == "body" }
         end
       end


### PR DESCRIPTION
This PR overrides ActiveRecords #saved_changes for Rails 5.1 and above and returns the changes from translations after a record was saved.

See also #777.