### PR TITLE
Bump Rails to 7.1

### DIFF
--- a/globalize.gemspec
+++ b/globalize.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.required_ruby_version = '>= 2.4.6'
 
-  s.add_dependency 'activerecord', '>= 4.2', '< 7.0'
-  s.add_dependency 'activemodel', '>= 4.2', '< 7.0'
+  s.add_dependency 'activerecord', '>= 4.2', '< 7.1'
+  s.add_dependency 'activemodel', '>= 4.2', '< 7.1'
   s.add_dependency 'request_store', '~> 1.0'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
This bumps Rails dependency to 7.1

I'm uncertain how high you want to go? Perhaps `< 8`? Or more conservatively `7.1`? 