### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,17 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql, sqlite3 ]
-        gemfile: [ '7.0.0', '6.1.3.1', '6.0.3.6', '5.2.5', '5.1.7', '4.2.11.3' ]
-        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        gemfile: [ '7.0.1', '6.1.3.1', '6.0.3.6', '5.2.5', '5.1.7', '4.2.11.3' ]
+        ruby: [ '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
         exclude:
+          - ruby: '3.1'
+            gemfile: '6.0.3.6'
+          - ruby: '3.1'
+            gemfile: '5.2.5'
+          - ruby: '3.1'
+            gemfile: '5.1.7'
+          - ruby: '3.1'
+            gemfile: '4.2.11.3'
           - ruby: '3.0'
             gemfile: '5.2.5'
           - ruby: '3.0'
@@ -26,11 +34,11 @@ jobs:
           - ruby: '2.7'
             gemfile: '4.2.11.3'
           - ruby: '2.6'
-            gemfile: '7.0.0'
+            gemfile: '7.0.1'
           - ruby: '2.5'
-            gemfile: '7.0.0'
+            gemfile: '7.0.1'
           - ruby: '2.4'
-            gemfile: '7.0.0'
+            gemfile: '7.0.1'
           - ruby: '2.4'
             gemfile: '6.1.3.1'
           - ruby: '2.4'

--- a/Appraisals
+++ b/Appraisals
@@ -6,7 +6,7 @@ RAILS_VERSIONS = %w[
   5.2.5
   6.0.3.6
   6.1.3.1
-  7.0.0
+  7.0.1
 ]
 
 RAILS_VERSIONS.each do |version|

--- a/gemfiles/rails_7.0.1.gemfile
+++ b/gemfiles/rails_7.0.1.gemfile
@@ -3,8 +3,8 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.4", platforms: [:ruby, :rbx]
-gem "activemodel", "7.0.0"
-gem "activerecord", "7.0.0"
+gem "activemodel", "7.0.1"
+gem "activerecord", "7.0.1"
 
 group :mysql do
   gem "mysql2", platforms: [:ruby, :rbx]


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

In addition to the config changes to the `test.yml` file - adding 3.1 to the matrix and excluding unsupported entries, it's necessary to update from ActiveRecord/ActiveSupport 7.0.0 to 7.0.1, as that's the minimum 7.x version that supports Ruby 3.1.

Everything runs green.