### PR TITLE
Changed serialize method in Rails 6.1.0+

### DIFF
--- a/lib/patches/active_record/rails6_1/serialization.rb
+++ b/lib/patches/active_record/rails6_1/serialization.rb
@@ -2,7 +2,7 @@ module Globalize
   module AttributeMethods
     module Serialization
       def serialize(attr_name, class_name_or_coder = Object, **options)
-        super(attr_name, class_name_or_coder, options)
+        super(attr_name, class_name_or_coder, **options)
 
         coder = if class_name_or_coder == ::JSON
                   ::ActiveRecord::Coders::JSON

--- a/lib/patches/active_record/rails6_1/serialization.rb
+++ b/lib/patches/active_record/rails6_1/serialization.rb
@@ -1,0 +1,22 @@
+module Globalize
+  module AttributeMethods
+    module Serialization
+      def serialize(attr_name, class_name_or_coder = Object, **options)
+        super(attr_name, class_name_or_coder, options)
+
+        coder = if class_name_or_coder == ::JSON
+                  ::ActiveRecord::Coders::JSON
+                elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
+                  class_name_or_coder
+                else
+                  ::ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
+                end
+
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = coder
+      end
+    end
+  end
+end
+
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,5 +1,7 @@
 if ::ActiveRecord.version < Gem::Version.new("5.1.0")
   require_relative 'rails4/serialization'
-else
+elsif ::ActiveRecord.version < Gem::Version.new("6.1.0")
   require_relative 'rails5_1/serialization'
+else
+  require_relative 'rails6_1/serialization'
 end


### PR DESCRIPTION
[https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize](https://api.rubyonrails.org/v6.1.0/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize)

`serialize(attr_name, class_name_or_coder = Object, **options)`
