### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,18 @@ jobs:
       matrix:
         database: [ mysql, postgresql, sqlite3 ]
         gemfile: [ '7.0.1', '6.1.3.1', '6.0.3.6', '5.2.5', '5.1.7', '4.2.11.3' ]
-        ruby: [ '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
         exclude:
+          - ruby: '3.2'
+            gemfile: '6.1.3.1'
+          - ruby: '3.2'
+            gemfile: '6.0.3.6'
+          - ruby: '3.2'
+            gemfile: '5.2.5'
+          - ruby: '3.2'
+            gemfile: '5.1.7'
+          - ruby: '3.2'
+            gemfile: '4.2.11.3'
           - ruby: '3.1'
             gemfile: '6.0.3.6'
           - ruby: '3.1'
@@ -47,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get update
     - run: sudo apt-get install libpq-dev postgresql-client -y
       if: matrix.database == 'postgresql'
@@ -57,6 +67,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        bundler: 2.3.26
     - run: bundle exec rake db:create db:migrate
     - run: bundle exec rake test
 


### PR DESCRIPTION
Also updates checkout action version.
Fixes bundler to 2.3.26 to support legacy Rubies (Bundler 2.4+ no longer supports Ruby 2.5 and earlier).

Everything runs green on my fork.