### PR TITLE
Only add to ignored columns if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globalize Changelog
 
+## Unreleased
+
+* Don't specify `ignored_columns` unless necessary [#806](https://github.com/globalize/globalize/pull/806) by [Pat Leamon](https://github.com/stiak)
+
 ## 6.3.0 (2023-10-22)
 
 * Support ruby 3.2 rails 7.1 (#810)(https://github.com/globalize/globalize/pull/810) by [Shinichi Maeshima](https://github.com/willnet)

--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -41,8 +41,14 @@ module Globalize
 
         begin
           if database_connection_possible?
-            self.ignored_columns += translated_attribute_names.map(&:to_s)
-            reset_column_information
+            translated_attribute_name_strings = translated_attribute_names.map(&:to_s)
+            # Only ignore columns if they exist.  This allows queries to remain as .*
+            # instead of using explicit column names
+            attributes_that_exist = column_names & translated_attribute_name_strings
+            if attributes_that_exist.any?
+              self.ignored_columns += attributes_that_exist
+              reset_column_information
+            end
           end
         rescue ::ActiveRecord::NoDatabaseError
           warn 'Unable to connect to a database. Globalize skipped ignoring columns of translated attributes.'

--- a/test/data/models/in_progress.rb
+++ b/test/data/models/in_progress.rb
@@ -1,0 +1,3 @@
+class InProgress < ActiveRecord::Base
+  translates :name
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -268,4 +268,13 @@ ActiveRecord::Schema.define do
     t.string  :name
     t.string  :locale
   end
+
+  create_table :in_progresses, :force => true do |t|
+    t.string  :name
+  end
+
+  create_table :in_progress_translations, :force => true do |t|
+    t.string  :locale
+    t.string  :name
+  end
 end

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -361,4 +361,14 @@ class AttributesTest < Minitest::Spec
       assert_equal 'titolo', artwork.title(:it)
     end
   end
+
+  describe '#ignored_columns' do
+    it 'sets ignored_columns when present on the original table' do
+      assert_equal ["name"], InProgress.ignored_columns
+    end
+
+    it 'has empty ignored columns if columns are not present on the source table' do
+      assert_equal [], Post.ignored_columns
+    end
+  end
 end


### PR DESCRIPTION
In rails 5.2 and 6.1 (not sure about later) adding anything to ignored columns makes rails switch to explicit columns in model queries.  I'd prefer to keep the .* to keep the queries easy to read in our monitoring.

I'd love a pointer to an appropriate place to add tests for these changes (currently I've put it in `attributes_test.rb`).

![mysql2-reader__env_production____Datadog](https://github.com/user-attachments/assets/9caf2978-b128-4e37-b111-e74fc9c7f3c8)

