### PR TITLE
Fix Compatibility Issue with Audited Gem and Globalize Gem

### DIFF
--- a/lib/patches/active_record/rails6_1/serialization.rb
+++ b/lib/patches/active_record/rails6_1/serialization.rb
@@ -3,7 +3,7 @@ module Globalize
     module Serialization
       def serialize(attr_name, class_name_or_coder = Object, **options)
         super(attr_name, class_name_or_coder, **options)
-        if defined? globalize_serialized_attributes
+        if defined? self.globalize_serialized_attributes
           coder = if class_name_or_coder == ::JSON
                     ::ActiveRecord::Coders::JSON
                   elsif %i[load dump].all? { |x| class_name_or_coder.respond_to?(x) }

--- a/lib/patches/active_record/rails6_1/serialization.rb
+++ b/lib/patches/active_record/rails6_1/serialization.rb
@@ -3,17 +3,17 @@ module Globalize
     module Serialization
       def serialize(attr_name, class_name_or_coder = Object, **options)
         super(attr_name, class_name_or_coder, **options)
-
-        coder = if class_name_or_coder == ::JSON
-                  ::ActiveRecord::Coders::JSON
-                elsif [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
-                  class_name_or_coder
-                else
-                  ::ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
-                end
-
-        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
-        self.globalize_serialized_attributes[attr_name] = coder
+        if defined? globalize_serialized_attributes
+          coder = if class_name_or_coder == ::JSON
+                    ::ActiveRecord::Coders::JSON
+                  elsif %i[load dump].all? { |x| class_name_or_coder.respond_to?(x) }
+                    class_name_or_coder
+                  else
+                    ::ActiveRecord::Coders::YAMLColumn.new(attr_name, class_name_or_coder)
+                  end
+          self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+          self.globalize_serialized_attributes[attr_name] = coder
+        end
       end
     end
   end


### PR DESCRIPTION
When attempting to install the Audited gem after the Globalize gem, you may encounter the following error:

ruby
Copy code
undefined local variable or method 'globalize_serialized_attributes' for Audited::Audit:Class
This error occurs because the Audited gem is trying to access the globalize_serialized_attributes method, which is undefined in the context of the Audited gem.

Error Message
 (called from block (2 levels) in require at C:/Ruby32-x64/lib/ruby/site_ruby/3.2.0/bundler/runtime.rb:60)
C:/Ruby32-x64/lib/ruby/gems/3.2.0/gems/activerecord-7.1.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined local variable or method `globalize_serialized_attributes' for Audited::Audit:Class 