### PR TITLE
Patch ActiveSupport in Rails 7.1.0+

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -78,15 +78,7 @@ module Globalize
       end
 
       def enable_serializable_attribute(attr_name)
-        serializer = self.globalize_serialized_attributes[attr_name]
-        if serializer.present?
-          if defined?(::ActiveRecord::Coders::YAMLColumn) &&
-            serializer.is_a?(::ActiveRecord::Coders::YAMLColumn)
-            serializer = serializer.object_class
-          end
-
-          translation_class.send :serialize, attr_name, serializer
-        end
+        translation_class.send :serialize, attr_name, coder: YAML
       end
 
       def setup_translates!(options)

--- a/lib/patches/active_record/rails7_1/serialization.rb
+++ b/lib/patches/active_record/rails7_1/serialization.rb
@@ -4,7 +4,7 @@ module Globalize
       def serialize(attr_name, **options)
         super(attr_name, **options)
 
-        coder = if class_name_or_coder == ::JSON
+        coder = if options[:coder] == ::JSON
                   ::ActiveRecord::Coders::JSON
                 else
                   ::ActiveRecord::Coders::YAMLColumn.new(attr_name)

--- a/lib/patches/active_record/rails7_1/serialization.rb
+++ b/lib/patches/active_record/rails7_1/serialization.rb
@@ -1,0 +1,20 @@
+module Globalize
+  module AttributeMethods
+    module Serialization
+      def serialize(attr_name, class_name_or_coder = nil, **options)
+        super(attr_name, **options)
+
+        coder = if class_name_or_coder == ::JSON
+                  ::ActiveRecord::Coders::JSON
+                else
+                  ::ActiveRecord::Coders::YAMLColumn.new(attr_name)
+                end
+
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = coder
+      end
+    end
+  end
+end
+
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/lib/patches/active_record/rails7_1/serialization.rb
+++ b/lib/patches/active_record/rails7_1/serialization.rb
@@ -1,7 +1,7 @@
 module Globalize
   module AttributeMethods
     module Serialization
-      def serialize(attr_name, class_name_or_coder = nil, **options)
+      def serialize(attr_name, **options)
         super(attr_name, **options)
 
         coder = if class_name_or_coder == ::JSON

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -2,6 +2,8 @@ if ::ActiveRecord.version < Gem::Version.new("5.1.0")
   require_relative 'rails4/serialization'
 elsif ::ActiveRecord.version < Gem::Version.new("6.1.0")
   require_relative 'rails5_1/serialization'
-else
+elsif ::ActiveRecord.version < Gem::Version.new("7.1.0")
   require_relative 'rails6_1/serialization'
+else
+  require_relative 'rails7_1/serialization'
 end

--- a/test/data/models/serialized_attr.rb
+++ b/test/data/models/serialized_attr.rb
@@ -5,13 +5,13 @@ end
 
 class ArraySerializedAttr < ActiveRecord::Base
   self.table_name = 'serialized_attrs'
-  serialize :meta, Array
+  serialize :meta, :coder => JSON, :type => Array
   translates :meta
 end
 
 class JSONSerializedAttr < ActiveRecord::Base
   self.table_name = 'serialized_attrs'
-  serialize :meta, JSON
+  serialize :meta, :coder => JSON
   translates :meta
 end
 

--- a/test/data/models/serialized_hash.rb
+++ b/test/data/models/serialized_hash.rb
@@ -1,4 +1,4 @@
 class SerializedHash < ActiveRecord::Base
-  serialize :meta, Hash
+  serialize :meta, :coder  => JSON
   translates :meta
 end


### PR DESCRIPTION
Rails.7.x has changed the way it handles serialize.
you no longer need to pass a second parameter

https://github.com/rails/rails/blob/main/activerecord/lib/active_record/attribute_methods/serialization.rb#L183C14-L183C14

```ruby
def serialize(attr_name, class_name_or_coder = nil, coder: nil, type: Object, yaml: {}, **options)
  unless class_name_or_coder.nil?
    if class_name_or_coder == ::JSON || [:load, :dump].all? { |x| class_name_or_coder.respond_to?(x) }
      ActiveRecord.deprecator.warn(<<~MSG)
        Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.

        Please pass the coder as a keyword argument:

          serialize #{attr_name.inspect}, coder: #{class_name_or_coder}
      MSG
      coder = class_name_or_coder
    else
      ActiveRecord.deprecator.warn(<<~MSG)
        Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

        Please pass the class as a keyword argument:

          serialize #{attr_name.inspect}, type: #{class_name_or_coder.name}
      MSG
      type = class_name_or_coder
    end
  end
```