### PR TITLE
Fix InverseOfAssociationNotFoundError when class is called Translation

### DIFF
--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -57,7 +57,7 @@ module Globalize
           end
 
           klass.belongs_to :globalized_model,
-            class_name: self.name,
+            class_name: "::" + self.name,
             foreign_key: translation_options[:foreign_key],
             inverse_of: :translations,
             touch: translation_options.fetch(:touch, false)


### PR DESCRIPTION
We have a classed called `Translation` that translates a value.

```
class Translation < ApplicationRecord
  translates :value
end
```

This causes the following error:
```
      ActiveRecord::InverseOfAssociationNotFoundError:
        Could not find the inverse association for globalized_model (:translations in Translation)
      # /home/circleci/bundle/ruby/2.7.0/gems/activerecord-5.2.8.1/lib/active_record/reflection.rb:236:in `check_validity_of_inverse!'
```

The problems seems to be that globalize also uses classes called Translation internally. This results in a confusion between `Translation` and `Translation::Translation` when Rails checks the inverse_of.

I fixed this by prepending `"::"` to the class name, making sure that the class is loaded from the top-level namespace.