### PR TITLE
Do not create empty current translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Gemfile*.lock
 *.gem
 .rbx
 .ruby-version
+.ruby-gemset
 test/globalize_test.log
 gemfiles/*.lock
 tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Coerce locale to symbol in `Attributes#contains?` [#844](https://github.com/globalize/globalize/pull/844) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
+* Prevent creation of empty current translation [#832](https://github.com/globalize/globalize/pull/832) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
 
 ## 7.1.1 (2025-12-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Globalize Changelog
 
+## 7.1.3 (2026-05-25)
+
+* Prevent creation of empty current translation [#832](https://github.com/globalize/globalize/pull/832) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
+
 ## 7.1.2 (2026-05-18)
 
 * Coerce locale to symbol in `Attributes#contains?` [#844](https://github.com/globalize/globalize/pull/844) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
-* Prevent creation of empty current translation [#832](https://github.com/globalize/globalize/pull/832) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
 
 ## 7.1.1 (2025-12-24)
 

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -143,20 +143,13 @@ module Globalize
         Globalize.fallbacks(locale)
       end
 
-      class_eval <<~RUBY, __FILE__, __LINE__ + 1
-        def save(...)
-          result = Globalize.with_locale(translation.locale || I18n.default_locale) do
-            without_fallbacks do
-              super
-            end
-          end
-          if result
-            globalize.clear_dirty
-          end
+      def save(...)
+        globalize_clear_dirty { super }
+      end
 
-          result
-        end
-      RUBY
+      def save!(...)
+        globalize_clear_dirty { super }
+      end
 
       def column_for_attribute name
         return super if translated_attribute_names.exclude?(name)
@@ -245,6 +238,12 @@ module Globalize
         return nil unless translated?(name)
 
         globalize.fetch(options[:locale] || Globalize.locale, name)
+      end
+
+      def globalize_clear_dirty
+        result = without_fallbacks { yield }
+        globalize.clear_dirty if result
+        result
       end
     end
   end

--- a/lib/globalize/version.rb
+++ b/lib/globalize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Globalize
-  Version = "7.1.2"
+  Version = "7.1.3"
 end

--- a/test/data/models/artwork.rb
+++ b/test/data/models/artwork.rb
@@ -1,4 +1,4 @@
 class Artwork < ActiveRecord::Base
-  translates :title
+  translates :title, :subtitle
   accepts_nested_attributes_for :translations
 end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -248,6 +248,7 @@ ActiveRecord::Schema.define do
     t.string     :locale
     t.references :artwork
     t.string     :title, null: false
+    t.string     :subtitle, null: false
   end
 
   create_table :questions, :force => true do |t|

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -319,12 +319,9 @@ class AttributesTest < Minitest::Spec
       ActiveRecord::JDBCError
     )
 
-    it 'does not save a record with an empty required field' do
-      err = assert_raises ActiveRecord::StatementInvalid do
-        Artwork.create
-      end
-
-      assert_match(/#{DB_EXCEPTIONS.join('|')}/, err.message)
+    it 'does not create an empty translation record' do
+      artwork = Artwork.create
+      assert_equal 0, artwork.translations.length
     end
 
     it 'saves a record with a filled required field' do

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -324,21 +324,31 @@ class AttributesTest < Minitest::Spec
       assert_equal 0, artwork.translations.length
     end
 
-    it 'saves a record with a filled required field' do
+    it 'does not save a record with an empty required field' do
+      err = assert_raises ActiveRecord::StatementInvalid do
+        Artwork.create(title: 'foo')
+      end
+
+      assert_match(/#{DB_EXCEPTIONS.join('|')}/, err.message)
+    end
+
+    it 'saves a record with all required fields filled' do
       artwork = Artwork.new
       artwork.title = "foo"
+      artwork.subtitle = "bar"
       artwork.save!
       artwork.reload
 
       assert_equal 1, artwork.translations.length
       assert_equal 'foo', artwork.title
+      assert_equal 'bar', artwork.subtitle
     end
 
     it 'does not save a record with an empty required field using nested attributes' do
       err = assert_raises ActiveRecord::StatementInvalid do
         Artwork.create(:translations_attributes => {
-          "0" => { :locale => 'en', :title => 'title' },
-          "1" => { :locale => 'it' }
+          "0" => { :locale => 'en', :title => 'title', :subtitle => 'sub' },
+          "1" => { :locale => 'it', :subtitle => 'sub' }
         })
       end
 
@@ -347,8 +357,8 @@ class AttributesTest < Minitest::Spec
 
     it 'saves a record with a filled required field using nested attributes' do
       artwork = Artwork.new(:translations_attributes => {
-        "0" => { :locale => 'en', :title => 'title' },
-        "1" => { :locale => 'it', :title => 'titolo' }
+        "0" => { :locale => 'en', :title => 'title', :subtitle => 'sub' },
+        "1" => { :locale => 'it', :title => 'titolo', :subtitle => 'sottotitolo' }
       })
       artwork.save!
       artwork.reload

--- a/test/globalize/fallbacks_test.rb
+++ b/test/globalize/fallbacks_test.rb
@@ -179,9 +179,14 @@ class FallbacksTest < Minitest::Spec
         question.update(params)
 
         assert_equal question.errors[:title], ["can't be blank"]
+
+        assert_raises ActiveRecord::RecordInvalid do
+          question.update!(params)
+        end
+
+        question.update!(title: 'Was ist das?')
       end
     end
-
   end
 
   describe 'STI model' do


### PR DESCRIPTION
Hello, I noticed that Globalize creates an empty translation for current locale on save (due to a call to `translation`).
I believe this is unnecessary. Also, it fails to save if there are validations on translation_class.

In the previous implementation `translation.locale` is always `Globalize.locale`. 
And `Globalize.locale` will be always set, so `|| I18n.default_locale` part didn't make sense either. 
Thus the `Globalize.with_locale` block call would not do anything except initializing the translation instance.

Also, it was happening only on `save` and not on `save!`. The PR addresses the inconsistency by patching both methods.