### PR TITLE
Fixed migration rollback not working when `:migrate_data` option is true

### DIFF
--- a/lib/globalize/active_record/migration.rb
+++ b/lib/globalize/active_record/migration.rb
@@ -66,9 +66,9 @@ module Globalize
           move_data_to_model_table if options[:migrate_data]
           drop_translations_index
           drop_translation_table
-          
+
           translated_attribute_names.clear
-          
+
           clear_schema_cache!
         end
 
@@ -159,12 +159,11 @@ module Globalize
             translated_attribute_names.inject(fields_to_update={}) do |f, name|
               f.update({name.to_sym => translated_record[name.to_s]})
               # Remove attributes that will no longer be translated
-              
             end
 
             # Now, update the actual model's record with the hash.
             model.where(model.primary_key.to_sym => translated_record[model.primary_key]).update_all(fields_to_update)
-          end          
+          end
         end
 
         def validate_translated_fields


### PR DESCRIPTION
The current implementation of the method that moves translated attributes back to the source table was modifying the translated_attribute_names within the loop over all records. This caused the execution to break on the n + 1st iteration when translated_attribute_names has n entries.
 
as deleting the translated attributes there is not really necessary, i moved it to the end of the overall rollback.