### PR TITLE
Support the ActiveModel Attribute API for translated attributes

### DIFF
--- a/lib/globalize/active_record/act_macro.rb
+++ b/lib/globalize/active_record/act_macro.rb
@@ -31,6 +31,9 @@ module Globalize
           # Detect and apply serialization.
           enable_serializable_attribute(attr_name)
 
+          # Propagate custom attribute types to the translation class.
+          propagate_attribute_type(attr_name)
+
           # Create accessors for the attribute.
           define_translated_attr_accessor(attr_name)
           define_translations_accessor(attr_name)
@@ -64,6 +67,22 @@ module Globalize
         self.translated_attribute_names = []
         self.translation_options        = options
         self.fallbacks_for_empty_translations = options[:fallbacks_for_empty_translations]
+      end
+
+      def propagate_attribute_type(attr_name)
+        # Don't override types for serialized attributes
+        return if globalize_serialized_attributes.key?(attr_name)
+
+        begin
+          type = attribute_types[attr_name.to_s]
+        rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::NoDatabaseError
+          # Unable to infer type for attribute because database table for model is not available
+          return
+        end
+
+        if type && type.class != ::ActiveRecord::Type::Value
+          translation_class.attribute(attr_name, type)
+        end
       end
 
       def enable_serializable_attribute(attr_name)

--- a/lib/globalize/active_record/class_methods.rb
+++ b/lib/globalize/active_record/class_methods.rb
@@ -28,6 +28,14 @@ module Globalize
         )
       end
 
+      def attribute(name, ...)
+        super
+        if translated?(name)
+          type = attribute_types[name.to_s]
+          translation_class.attribute(name, type) if type
+        end
+      end
+
       def translated?(name)
         translated_attribute_names.include?(name.to_sym)
       end
@@ -114,9 +122,21 @@ module Globalize
       end
 
       def define_translations_accessor(name)
-        attribute(name, ::ActiveRecord::Type::Value.new)
+        unless custom_translated_attribute_type?(name)
+          attribute(name, ::ActiveRecord::Type::Value.new)
+        end
         define_translations_reader(name)
         define_translations_writer(name)
+      end
+
+      def custom_translated_attribute_type?(name)
+        begin
+          type = attribute_types[name.to_s]
+        rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::NoDatabaseError
+          # Unable to infer type for attribute because database table for model is not available
+          return false
+        end
+        type && type.class != ::ActiveRecord::Type::Value
       end
 
       def database_connection_possible?

--- a/lib/globalize/active_record/instance_methods.rb
+++ b/lib/globalize/active_record/instance_methods.rb
@@ -26,6 +26,8 @@ module Globalize
         return super(name, value, *args, &block) unless translated?(name)
 
         options = {:locale => Globalize.locale}.merge(args.first || {})
+        type = self.class.type_for_attribute(name.to_s)
+        value = type.cast(value) if type
 
         globalize.write(options[:locale], name, value)
       end

--- a/lib/globalize/active_record/translated_attributes_query.rb
+++ b/lib/globalize/active_record/translated_attributes_query.rb
@@ -94,7 +94,12 @@ module Globalize
       def parse_translated_conditions(opts)
         if opts.is_a?(Hash) && respond_to?(:translated_attribute_names) && (keys = opts.symbolize_keys.keys & translated_attribute_names).present?
           opts = opts.dup
-          keys.each { |key| opts[translated_column_name(key)] = opts.delete(key) || opts.delete(key.to_s) }
+          keys.each do |key|
+            value = opts.delete(key) || opts.delete(key.to_s)
+            type = type_for_attribute(key.to_s)
+            value = type.cast(value) if type
+            opts[translated_column_name(key)] = value
+          end
           opts
         end
       end

--- a/test/data/models/typed_post.rb
+++ b/test/data/models/typed_post.rb
@@ -1,0 +1,17 @@
+class StrippedStringType < ActiveRecord::Type::String
+  def cast(value)
+    value.is_a?(String) ? value.strip : super
+  end
+end
+
+class TypedPost < ActiveRecord::Base
+  attribute :title, StrippedStringType.new
+  translates :title
+end
+
+class ReverseTypedPost < ActiveRecord::Base
+  self.table_name = "typed_posts"
+
+  translates :title
+  attribute :title, StrippedStringType.new
+end

--- a/test/data/schema.rb
+++ b/test/data/schema.rb
@@ -277,4 +277,13 @@ ActiveRecord::Schema.define do
     t.string  :locale
     t.string  :name
   end
+
+  create_table :typed_posts, :force => true do |t|
+  end
+
+  create_table :typed_post_translations, :force => true do |t|
+    t.string     :locale
+    t.references :typed_post
+    t.string     :title
+  end
 end

--- a/test/globalize/active_model_attributes_test.rb
+++ b/test/globalize/active_model_attributes_test.rb
@@ -1,0 +1,92 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class ActiveModelAttributesTest < Minitest::Spec
+  describe "attribute type preservation" do
+    it "preserves custom attribute type on the model" do
+      type = TypedPost.type_for_attribute("title")
+      assert_instance_of StrippedStringType, type
+    end
+
+    it "propagates custom attribute type to the translation class" do
+      type = TypedPost.translation_class.type_for_attribute("title")
+      assert_instance_of StrippedStringType, type
+    end
+  end
+
+  describe "type casting on write" do
+    it "casts value using custom attribute type when writing" do
+      post = TypedPost.new
+      post.title = "  hello  "
+      assert_equal "hello", post.title
+    end
+
+    it "casts value when using write_attribute" do
+      post = TypedPost.new
+      post.write_attribute(:title, "  hello  ")
+      assert_equal "hello", post.title
+    end
+
+    it "casts value using custom attribute type when using multiple translation setter" do
+      post = TypedPost.new
+      post.title_translations = {:en => " hello ", :fr => " bonjour " }
+      assert_translated post, :en, :title, 'hello'
+      assert_translated post, :fr, :title, 'bonjour'
+    end
+  end
+
+  describe "type casting on save" do
+    it "persists the cast value in the translation record" do
+      post = TypedPost.create!(title: "  hello  ")
+      translation = post.translations.first
+      assert_equal "hello", translation.title
+    end
+
+    it "reads back the cast value after reload" do
+      post = TypedPost.create!(title: "  hello  ")
+      post.reload
+      assert_equal "hello", post.title
+    end
+
+    it "persists the casted values using custom attribute type when using multiple translation setter" do
+      post = TypedPost.new
+      post.title_translations = {:en => " hello ", :fr => " bonjour " }
+      post.save!
+      post.reload
+
+      assert_translated post, :en, :title, 'hello'
+      assert_translated post, :fr, :title, 'bonjour'
+    end
+  end
+
+  describe "type casting in queries" do
+    it "casts query values using the custom attribute type" do
+      TypedPost.create!(title: "hello")
+      assert_equal 1, TypedPost.where(title: "  hello  ").count
+    end
+  end
+
+  describe "when translates is called before attribute" do
+    it "propagates custom attribute type to the translation class" do
+      type = ReverseTypedPost.translation_class.type_for_attribute("title")
+      assert_instance_of StrippedStringType, type
+    end
+
+    it "casts value using custom attribute type when writing" do
+      post = ReverseTypedPost.new
+      post.title = "  hello  "
+      assert_equal "hello", post.title
+    end
+
+    it "persists the cast value in the translation record" do
+      post = ReverseTypedPost.create!(title: "  hello  ")
+      translation = post.translations.first
+      assert_equal "hello", translation.title
+    end
+
+    it "reads back the cast value after reload" do
+      post = ReverseTypedPost.create!(title: "  hello  ")
+      post.reload
+      assert_equal "hello", post.title
+    end
+  end
+end


### PR DESCRIPTION
Supports calling ActiveModel's `attribute` method and Globalize's `translates` method in either order.

Fixes #611 