### PR TITLE
Avoid constant cache invalidations in translated relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globalize Changelog
 
+## Unreleased
+
+* Avoid constant cache invalidations in translated relations [#842](https://github.com/globalize/globalize/pull/842) by [Eisuke Matsushita](https://github.com/wt-l00)
+
 ## 7.1.3 (2026-05-25)
 
 * Prevent creation of empty current translation [#832](https://github.com/globalize/globalize/pull/832) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)

--- a/lib/globalize/active_record/translated_attributes_query.rb
+++ b/lib/globalize/active_record/translated_attributes_query.rb
@@ -1,19 +1,19 @@
 module Globalize
   module ActiveRecord
-    module TranslatedAttributesQuery
-      class WhereChain < ::ActiveRecord::QueryMethods::WhereChain
-        def not(opts, *rest)
-          if parsed = @scope.clone.parse_translated_conditions(opts)
-            @scope.join_translations.where.not(parsed, *rest)
-          else
-            super
-          end
+    class TranslatedAttributesWhereChain < ::ActiveRecord::QueryMethods::WhereChain
+      def not(opts, *rest)
+        if parsed = @scope.clone.parse_translated_conditions(opts)
+          @scope.join_translations.where.not(parsed, *rest)
+        else
+          super
         end
       end
+    end
 
+    module TranslatedAttributesQuery
       def where(opts = :chain, *rest)
         if opts == :chain
-          WhereChain.new(spawn)
+          TranslatedAttributesWhereChain.new(spawn)
         elsif parsed = parse_translated_conditions(opts)
           join_translations(super(parsed, *rest))
         else


### PR DESCRIPTION
## Summary

  This moves `WhereChain` out of `Globalize::ActiveRecord::TranslatedAttributesQuery`.

  `TranslatedAttributesQuery` is extended into translated relations during relation construction. https://github.com/globalize/globalize/blob/86fd1ba78fd413100bdfb362ba2b4a93210d8d2d/lib/globalize/active_record/class_methods.rb#L75-L77. 
When that module contains constants, Ruby invalidates constant caches each time the module is extended. Keeping `WhereChain` as a sibling constant
  avoids those repeated invalidations while preserving the existing `where.not` behavior.

  ## Benchmark

  Workload:

  ```ruby
  require "globalize"
  require "support/database"
  Globalize::Test::Database.connect
  require "data/models"

  key = :constant_cache_invalidations
  n = Integer(ENV.fetch("N", "20000"))
  warmup = Integer(ENV.fetch("WARMUP", "1000"))

  workload = ->(i) { i.times { User.where; User.where(:name => "foo") } }

  workload.call(warmup)
  GC.start
  before = RubyVM.stat[key]
  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  workload.call(n)

  puts "constant_cache_invalidations=#{RubyVM.stat[key] - before}"
  puts "elapsed=#{format("%.3f", Process.clock_gettime(Process::CLOCK_MONOTONIC) - started)}s"
```

  Environment:

  - Ruby 4.0.3
  - Rails 8.1.3
  - sqlite3 in-memory test database
  - N=20000

  | Mode | Revision | Constant cache invalidations | Elapsed |
  |---|---:|---:|---:|
  | without YJIT, before | 86fd1ba | 40000 | 2.255s |
  | without YJIT, after | this branch | 0 | 2.266s |
  | with YJIT, before | 86fd1ba | 40000 | 3.056s |
  | with YJIT, after | this branch | 0 | 1.504s |
