### PR TITLE
Fix Rails 7.2 serialization compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globalize Changelog
 
+## Unreleased
+
+* Fix `NameError: undefined local variable or method 'globalize_serialized_attributes'` when a gem loaded before Globalize (such as `audited`) serializes an attribute from its own `ActiveSupport.on_load(:active_record)` hook [#843](https://github.com/globalize/globalize/pull/843) by [Jatin Rajput](https://github.com/jatin-rajput829)
+
 ## 7.1.3 (2026-05-25)
 
 * Prevent creation of empty current translation [#832](https://github.com/globalize/globalize/pull/832) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)

--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -101,8 +101,5 @@ module Globalize
 end
 
 ActiveSupport.on_load(:active_record) do
-  ActiveRecord::Base.class_attribute :globalize_serialized_attributes, instance_writer: false
-  ActiveRecord::Base.globalize_serialized_attributes = {}
-
   ActiveRecord::Base.extend(Globalize::ActiveRecord::ActMacro)
 end

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -1,7 +1,7 @@
 module Globalize
   module AttributeMethods
     module Serialization
-      def serialize(attr_name, class_name_or_coder = nil, **options)
+      def serialize(attr_name, coder = nil, **options)
         if respond_to?(:globalize_serialized_attributes) &&
            respond_to?(:globalize_serialized_attributes=)
 
@@ -11,12 +11,12 @@ module Globalize
             globalize_serialized_attributes.dup
 
           self.globalize_serialized_attributes[attr_name] = {
-            coder: class_name_or_coder
+            coder: coder
           }.merge(options)
         end
 
-        if class_name_or_coder
-          super(attr_name, class_name_or_coder, **options)
+        if coder
+          super(attr_name, coder, **options)
         else
           super(attr_name, **options)
         end

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -1,7 +1,7 @@
 module Globalize
   module AttributeMethods
     module Serialization
-      def serialize(attr_name, **options)
+      def serialize(attr_name, class_name_or_coder = nil, **options)
         if respond_to?(:globalize_serialized_attributes) &&
            respond_to?(:globalize_serialized_attributes=)
 
@@ -10,10 +10,16 @@ module Globalize
           self.globalize_serialized_attributes =
             globalize_serialized_attributes.dup
 
-          self.globalize_serialized_attributes[attr_name] = options
+          self.globalize_serialized_attributes[attr_name] = {
+            coder: class_name_or_coder
+          }.merge(options)
         end
 
-        super(attr_name, **options)
+        if class_name_or_coder
+          super(attr_name, class_name_or_coder, **options)
+        else
+          super(attr_name, **options)
+        end
       end
     end
   end

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -10,16 +10,23 @@ module Globalize
           self.globalize_serialized_attributes =
             globalize_serialized_attributes.dup
 
-          self.globalize_serialized_attributes[attr_name] = {
-            coder: coder
-          }.merge(options)
+          serialization_options =
+            coder.is_a?(Class) &&
+            [Array, Hash].include?(coder) ?
+              { type: coder } :
+              { coder: coder }
+
+          self.globalize_serialized_attributes[attr_name] =
+            serialization_options.merge(options)
         end
 
-        if coder
-          super(attr_name, coder, **options)
-        else
-          super(attr_name, **options)
-        end
+        serialization_options =
+          coder.is_a?(Class) &&
+          [Array, Hash].include?(coder) ?
+            { type: coder } :
+            { coder: coder }
+
+        super(attr_name, **serialization_options, **options)
       end
     end
   end

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -2,14 +2,23 @@ module Globalize
   module AttributeMethods
     module Serialization
       def serialize(attr_name, **options)
-        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
-        self.globalize_serialized_attributes[attr_name] = options
+        if respond_to?(:globalize_serialized_attributes) &&
+           respond_to?(:globalize_serialized_attributes=)
 
-        # https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/attribute_methods/serialization.rb#L183
+          self.globalize_serialized_attributes ||= {}
+
+          self.globalize_serialized_attributes =
+            globalize_serialized_attributes.dup
+
+          self.globalize_serialized_attributes[attr_name] = options
+        end
+
         super(attr_name, **options)
       end
     end
   end
 end
 
-ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.prepend(
+  Globalize::AttributeMethods::Serialization
+)

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -2,8 +2,10 @@ module Globalize
   module AttributeMethods
     module Serialization
       def serialize(attr_name, **options)
-        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
-        self.globalize_serialized_attributes[attr_name] = options
+        # The reader lazily copies the parent's hash into a class-private one on
+        # first access, so mutating it in place cannot leak to a superclass and
+        # no dup is needed here.
+        globalize_serialized_attributes[attr_name] = options
 
         # https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/attribute_methods/serialization.rb#L183
         super(attr_name, **options)

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -2,10 +2,8 @@ module Globalize
   module AttributeMethods
     module Serialization
       def serialize(attr_name, **options)
-        # The reader lazily copies the parent's hash into a class-private one on
-        # first access, so mutating it in place cannot leak to a superclass and
-        # no dup is needed here.
-        globalize_serialized_attributes[attr_name] = options
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = options
 
         # https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/attribute_methods/serialization.rb#L183
         super(attr_name, **options)

--- a/lib/patches/active_record/rails7_2/serialization.rb
+++ b/lib/patches/active_record/rails7_2/serialization.rb
@@ -1,37 +1,15 @@
 module Globalize
   module AttributeMethods
     module Serialization
-      def serialize(attr_name, coder = nil, **options)
-        if respond_to?(:globalize_serialized_attributes) &&
-           respond_to?(:globalize_serialized_attributes=)
+      def serialize(attr_name, **options)
+        self.globalize_serialized_attributes = globalize_serialized_attributes.dup
+        self.globalize_serialized_attributes[attr_name] = options
 
-          self.globalize_serialized_attributes ||= {}
-
-          self.globalize_serialized_attributes =
-            globalize_serialized_attributes.dup
-
-          serialization_options =
-            coder.is_a?(Class) &&
-            [Array, Hash].include?(coder) ?
-              { type: coder } :
-              { coder: coder }
-
-          self.globalize_serialized_attributes[attr_name] =
-            serialization_options.merge(options)
-        end
-
-        serialization_options =
-          coder.is_a?(Class) &&
-          [Array, Hash].include?(coder) ?
-            { type: coder } :
-            { coder: coder }
-
-        super(attr_name, **serialization_options, **options)
+        # https://github.com/rails/rails/blob/7-2-stable/activerecord/lib/active_record/attribute_methods/serialization.rb#L183
+        super(attr_name, **options)
       end
     end
   end
 end
 
-ActiveRecord::AttributeMethods::Serialization::ClassMethods.prepend(
-  Globalize::AttributeMethods::Serialization
-)
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::Serialization)

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,15 +1,7 @@
-# `on_load(:active_record)` hooks run in registration order, so a gem
-# required before Globalize (e.g. `audited`) can define a model -- and
-# therefore call `serialize` -- from its own hook before any later Globalize
-# hook runs, reaching the `serialize` patch below while
-# `globalize_serialized_attributes` doesn't exist yet:
-#
-#   NameError: undefined local variable or method `globalize_serialized_attributes'
-#
-# Setting the attribute up here instead, unconditionally as this file loads,
-# guarantees it always exists before the patch does, regardless of gem load
-# order. `active_record` is already required by lib/globalize.rb by this
-# point, so `ActiveRecord::Base` is available without needing `on_load` at all.
+# Gem load order is not guaranteed, so another gem's on_load(:active_record)
+# hook can call `serialize` on a model before this one runs. Defining the
+# attribute unconditionally here, rather than inside a hook, ensures it
+# always exists before that happens.
 ActiveRecord::Base.class_attribute :globalize_serialized_attributes, instance_writer: false
 ActiveRecord::Base.globalize_serialized_attributes = {}
 

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,33 +1,17 @@
-module Globalize
-  module AttributeMethods
-    # Storage for the serialization options Globalize replays onto translation
-    # classes in +ActMacro#enable_serializable_attribute+.
-    #
-    # These accessors are deliberately defined here, in a module prepended
-    # alongside the patched +serialize+, rather than as a +class_attribute+
-    # inside an +ActiveSupport.on_load(:active_record)+ block. Hooks run in
-    # registration order, so a gem required before Globalize can define models
-    # -- and therefore call +serialize+ -- from its own hook, reaching the
-    # patched +serialize+ before Globalize's hook has run. That raised
-    # "NameError: undefined local variable or method
-    # `globalize_serialized_attributes'". Defining them next to the patch makes
-    # it impossible for one to exist without the other.
-    module SerializedAttributes
-      def globalize_serialized_attributes
-        @globalize_serialized_attributes ||=
-          if superclass.respond_to?(:globalize_serialized_attributes)
-            superclass.globalize_serialized_attributes.dup
-          else
-            {}
-          end
-      end
-
-      attr_writer :globalize_serialized_attributes
-    end
-  end
-end
-
-ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::SerializedAttributes)
+# `on_load(:active_record)` hooks run in registration order, so a gem
+# required before Globalize (e.g. `audited`) can define a model -- and
+# therefore call `serialize` -- from its own hook before any later Globalize
+# hook runs, reaching the `serialize` patch below while
+# `globalize_serialized_attributes` doesn't exist yet:
+#
+#   NameError: undefined local variable or method `globalize_serialized_attributes'
+#
+# Setting the attribute up here instead, unconditionally as this file loads,
+# guarantees it always exists before the patch does, regardless of gem load
+# order. `active_record` is already required by lib/globalize.rb by this
+# point, so `ActiveRecord::Base` is available without needing `on_load` at all.
+ActiveRecord::Base.class_attribute :globalize_serialized_attributes, instance_writer: false
+ActiveRecord::Base.globalize_serialized_attributes = {}
 
 if ::ActiveRecord.version < Gem::Version.new("7.1.0")
   require_relative 'rails6_1/serialization'

--- a/lib/patches/active_record/serialization.rb
+++ b/lib/patches/active_record/serialization.rb
@@ -1,3 +1,34 @@
+module Globalize
+  module AttributeMethods
+    # Storage for the serialization options Globalize replays onto translation
+    # classes in +ActMacro#enable_serializable_attribute+.
+    #
+    # These accessors are deliberately defined here, in a module prepended
+    # alongside the patched +serialize+, rather than as a +class_attribute+
+    # inside an +ActiveSupport.on_load(:active_record)+ block. Hooks run in
+    # registration order, so a gem required before Globalize can define models
+    # -- and therefore call +serialize+ -- from its own hook, reaching the
+    # patched +serialize+ before Globalize's hook has run. That raised
+    # "NameError: undefined local variable or method
+    # `globalize_serialized_attributes'". Defining them next to the patch makes
+    # it impossible for one to exist without the other.
+    module SerializedAttributes
+      def globalize_serialized_attributes
+        @globalize_serialized_attributes ||=
+          if superclass.respond_to?(:globalize_serialized_attributes)
+            superclass.globalize_serialized_attributes.dup
+          else
+            {}
+          end
+      end
+
+      attr_writer :globalize_serialized_attributes
+    end
+  end
+end
+
+ActiveRecord::AttributeMethods::Serialization::ClassMethods.send(:prepend, Globalize::AttributeMethods::SerializedAttributes)
+
 if ::ActiveRecord.version < Gem::Version.new("7.1.0")
   require_relative 'rails6_1/serialization'
 elsif ::ActiveRecord.version < Gem::Version.new("7.2.0")

--- a/test/globalize/serialization_load_order_test.rb
+++ b/test/globalize/serialization_load_order_test.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+require File.expand_path('../../test_helper', __FILE__)
+
+class SerializationLoadOrderTest < Minitest::Spec
+  # Gems required before Globalize (audited, for example) register their own
+  # `ActiveSupport.on_load(:active_record)` hooks first. Because hooks run in
+  # registration order, such a gem can define a model -- and therefore call
+  # `serialize` -- before Globalize's own hook has run, while Globalize's
+  # `serialize` patch is already in place. This has to work regardless of that
+  # ordering, so it is exercised in a subprocess where the hooks have not yet
+  # been flushed.
+  SCRIPT = <<~'RUBY'
+    require 'active_record'
+
+    ActiveSupport.on_load(:active_record) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; 'Audited::Audit'; end
+        self.table_name = 'audits'
+        serialize :audited_changes
+      end
+    end
+
+    require 'globalize'
+
+    ActiveRecord::Base # flushes the hooks, in registration order
+    puts 'ok'
+  RUBY
+
+  describe 'a model serialized from an earlier on_load hook' do
+    it 'does not raise NameError for globalize_serialized_attributes' do
+      lib = File.expand_path('../../../lib', __FILE__)
+      output = IO.popen(['ruby', '-I', lib, '-e', SCRIPT], err: [:child, :out], &:read)
+
+      assert_equal 'ok', output.strip
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a load-order issue in Rails 7.2 where `Globalize` can raise:

`NameError: undefined local variable or method 'globalize_serialized_attributes'`

This happens when another gem (e.g. `audited`) is loaded before Globalize and calls `serialize` from its own `ActiveSupport.on_load(:active_record)` hook. In that ordering, Globalize’s patched `serialize` can run before `globalize_serialized_attributes` is initialized.

