### PR TITLE
Coerce locale to symbol in Attributes#contains?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Globalize Changelog
 
+## Unreleased
+
+* Coerce locale to symbol in `Attributes#contains?` [#844](https://github.com/globalize/globalize/pull/844) by [Arkadiy Zabazhanov](https://github.com/pyromaniac)
+
 ## 7.1.1 (2025-12-24)
 
 * Fix automatic creation of empty stash entries for unassigned locales [#833](https://github.com/globalize/globalize/pull/833) by [Jules](https://github.com/jules-w2)

--- a/lib/globalize/active_record/attributes.rb
+++ b/lib/globalize/active_record/attributes.rb
@@ -11,6 +11,7 @@ module Globalize
       end
 
       def contains?(locale, name)
+        locale = locale.to_sym
         key?(locale) && self[locale].key?(name.to_s)
       end
 

--- a/test/globalize/attributes_test.rb
+++ b/test/globalize/attributes_test.rb
@@ -371,4 +371,38 @@ class AttributesTest < Minitest::Spec
       assert_equal [], Post.ignored_columns
     end
   end
+
+  describe Globalize::ActiveRecord::Attributes do
+    let(:stash) { Globalize::ActiveRecord::Attributes.new }
+
+    describe '#contains?' do
+      before { stash.write(:en, 'title', 'foo') }
+
+      it 'returns true for the locale and attribute that were written' do
+        assert_equal true, stash.contains?(:en, 'title')
+      end
+
+      it 'returns false for a locale that was not written' do
+        assert_equal false, stash.contains?(:de, 'title')
+      end
+
+      it 'returns false for an attribute that was not written' do
+        assert_equal false, stash.contains?(:en, 'body')
+      end
+
+      it 'accepts string locales (matches #[]/#read/#write coercion)' do
+        assert_equal true, stash.contains?('en', 'title')
+        assert_equal false, stash.contains?('de', 'title')
+      end
+
+      it 'accepts symbol attribute names' do
+        assert_equal true, stash.contains?(:en, :title)
+      end
+
+      it 'does not create empty stash entries for missing locales' do
+        stash.contains?(:de, 'title')
+        assert_equal false, stash.key?(:de)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What

Convert `locale` to `Symbol` at the top of `Attributes#contains?`, matching the coercion already done in `Attributes#[]` (and therefore in `#read`/`#write` which route through it).

## Why

#833 rewrote `contains?` to skip the `self[locale]` auto-vivification — which is a real fix — but in doing so dropped the implicit `to_sym` that `[]` performs:

```ruby
def [](locale)
  locale = locale.to_sym       # coerce
  self[locale] = {} unless has_key?(locale)
  self.fetch(locale)
end

def contains?(locale, name)
  key?(locale) && self[locale].key?(name.to_s)   # 7.0.0: routed via [], coerced. 7.1.x: not coerced.
end
```

The stash keys are always symbols because every write goes through `self[locale]`. After 7.1.0, calling `contains?("en", "title")` returns `false` even when `:en` is present.

This bites real callers — most visibly [globalize-accessors](https://github.com/globalize/globalize-accessors), which captures whatever was passed to `locales: …` in the macro and forwards it to `stash.contains?` from the generated getter. Something like:

```ruby
translates :title
globalize_accessors locales: I18n.available_locales.map(&:to_s)
```

silently breaks: `post.title_en` reads from the translation table instead of the in-memory stash, so writes made before save aren't visible. This is the pattern in our codebase and is what surfaced the regression for us.

## Repro

```ruby
stash = Globalize::ActiveRecord::Attributes.new
stash.write(:en, 'title', 'foo')

stash.contains?(:en, 'title')   # 7.0.0: true   | 7.1.x: true
stash.contains?('en', 'title')  # 7.0.0: true   | 7.1.x: false  ← regression
```